### PR TITLE
Fix Laravel CI workflow

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -1,4 +1,4 @@
-name: Laravel
+name: Laravel CI
 
 on:
   push:
@@ -6,30 +6,61 @@ on:
   pull_request:
     branches: [ "main" ]
 
-jobs:
-  laravel-tests:
+permissions:
+  contents: read
 
+concurrency:
+  group: laravel-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.0'
-    - uses: actions/checkout@v4
-    - name: Copy .env
-      run: php -r "file_exists('.env') || copy('.env.example', '.env');"
-    - name: Install Dependencies
-      run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
-    - name: Generate key
+        php-version: '8.4'
+        extensions: dom, fileinfo, mbstring, pdo_sqlite, sqlite3
+        coverage: none
+
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+
+    - name: Prepare environment
+      run: cp .env.example .env
+
+    - name: Install PHP dependencies
+      run: composer install --no-ansi --no-interaction --no-progress --prefer-dist
+
+    - name: Install frontend dependencies
+      run: npm install --no-audit --no-fund
+
+    - name: Build frontend assets
+      run: npm run build
+
+    - name: Generate application key
       run: php artisan key:generate
-    - name: Directory Permissions
-      run: chmod -R 777 storage bootstrap/cache
-    - name: Create Database
+
+    - name: Prepare SQLite database
       run: |
         mkdir -p database
         touch database/database.sqlite
-    - name: Execute tests (Unit and Feature tests) via PHPUnit/Pest
+
+    - name: Run database migrations
       env:
         DB_CONNECTION: sqlite
         DB_DATABASE: database/database.sqlite
-      run: php artisan test
+      run: php artisan migrate --force
+
+    - name: Run PHP tests
+      env:
+        DB_CONNECTION: sqlite
+        DB_DATABASE: database/database.sqlite
+      run: composer test


### PR DESCRIPTION
﻿Problem
GitHub Actions was using PHP 8.0 while the app requires PHP 8.2 or newer. The CI database and Vite assets also were not prepared enough for the feature test that renders the Inertia app.

Changes
- Move workflow to PHP 8.4 and Node 22.
- Add read-only workflow permissions and concurrency cancellation.
- Install frontend dependencies and build Vite assets before PHP feature tests.
- Prepare SQLite and run migrations before composer test.

Verification
- npm run build
- php artisan migrate --force with sqlite
- composer test

Closes #37
