### PR TITLE
Sanitize public repo hygiene

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,7 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+# Optional external SQLite database used by `php artisan expense:sync`.
+# Keep this path private and machine-local.
+# EXTERNAL_DB_PATH=/path/to/private/expense-data.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ database/expense_manager.db
 *.backup
 *.bak
 database/*.backup*
+
+# Local assistant/runtime context
+AGENTS.md
+.hermes/
+.codex/
+.claude/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,36 @@
+# Expense Manager
 
-php artisan expense:sync --db-path="/mnt/c/Users/rohit/Dropbox/ExpenseManager/Database/personal_finance.db" --dry-run
+Expense Manager is a Laravel and React application for tracking personal finances, managing accounts, and reviewing spending patterns.
 
-php artisan expense:sync --db-path="/mnt/c/Users/rohit/Dropbox/ExpenseManager/Database/personal_finance.db"
+## Local Setup
 
-php artisan expense:sync --db-path="/mnt/c/Users/rohit/Dropbox/ExpenseManager/Database/personal_finance.db" --force
+```bash
+composer install
+npm install
+cp .env.example .env
+php artisan key:generate
+touch database/database.sqlite
+php artisan migrate --seed
+npm run build
+composer test
+```
+
+## Development
+
+Run the backend and frontend during local development:
+
+```bash
+composer run dev
+```
+
+## Expense Sync
+
+The sync command accepts a local SQLite database path. Use your own private database path and keep it out of version control.
+
+```bash
+php artisan expense:sync --db-path="/path/to/private/expense-data.sqlite" --dry-run
+php artisan expense:sync --db-path="/path/to/private/expense-data.sqlite"
+php artisan expense:sync --db-path="/path/to/private/expense-data.sqlite" --force
+```
+
+Never commit local `.env` files, private databases, bank statements, or machine-specific assistant context.

--- a/app/Console/Commands/SyncExpenseData.php
+++ b/app/Console/Commands/SyncExpenseData.php
@@ -65,7 +65,11 @@ class SyncExpenseData extends Command
 
         } catch (Exception $e) {
             $this->error('❌ Sync failed: ' . $e->getMessage());
-            $this->error('Stack trace: ' . $e->getTraceAsString());
+
+            if ($this->output->isVerbose()) {
+                $this->error('Stack trace: ' . $e->getTraceAsString());
+            }
+
             return Command::FAILURE;
         }
     }
@@ -76,13 +80,14 @@ class SyncExpenseData extends Command
     private function displayConfiguration(?string $dbPath, bool $dryRun): void
     {
         $actualDbPath = $dbPath ?: config('sync.external_db_path');
+        $displayPath = $actualDbPath ?: 'Not configured';
 
         $this->info('📋 Configuration:');
         $this->table(
             ['Setting', 'Value'],
             [
-                ['External DB Path', $actualDbPath],
-                ['File Exists', file_exists($actualDbPath) ? '✅ Yes' : '❌ No'],
+                ['External DB Path', $displayPath],
+                ['File Exists', $actualDbPath && file_exists($actualDbPath) ? '✅ Yes' : '❌ No'],
                 ['Mode', $dryRun ? '🔍 Dry Run (no changes)' : '💾 Live Sync'],
                 ['Skip Duplicates', config('sync.sync_options.skip_duplicates') ? 'Yes' : 'No'],
                 ['Batch Size', config('sync.sync_options.batch_size')],

--- a/app/Services/ExpenseSyncService.php
+++ b/app/Services/ExpenseSyncService.php
@@ -25,7 +25,13 @@ class ExpenseSyncService
 
     public function __construct(string $externalDbPath = null)
     {
-        $this->externalDbPath = $externalDbPath ?: config('sync.external_db_path', '/mnt/c/Users/rohit/Dropbox/ExpenseManager/Database/personal_finance.db');
+        $configuredPath = $externalDbPath ?: config('sync.external_db_path');
+
+        if (!$configuredPath) {
+            throw new Exception('External database path is not configured. Pass --db-path or set EXTERNAL_DB_PATH.');
+        }
+
+        $this->externalDbPath = $configuredPath;
         $this->initializeExternalDb();
     }
 

--- a/config/sync.php
+++ b/config/sync.php
@@ -11,7 +11,7 @@ return [
     |
     */
 
-    'external_db_path' => env('EXTERNAL_DB_PATH', '/mnt/c/Users/rohit/Dropbox/ExpenseManager/Database/personal_finance.db'),
+    'external_db_path' => env('EXTERNAL_DB_PATH'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
﻿## Problem
Public repo hygiene needed a cleanup pass before portfolio documentation and statement-import checkpoint work. The repo contained personal sync paths in docs/config and did not explicitly ignore local assistant/runtime context.

## Changes
- Replaced the README personal Dropbox DB path with generic private-path examples.
- Added AGENTS.md, .hermes/, .codex/, and .claude/ to .gitignore.
- Removed hardcoded personal sync database defaults from config and service code.
- Added a generic EXTERNAL_DB_PATH example to .env.example.
- Improved expense:sync failure output so normal mode does not print local stack traces.

## Verification
- npm run build
- php artisan migrate --force with sqlite
- composer test
- Fixed-string scan for personal paths: no matches for Windows user paths, Dropbox, OneDrive, Obsidian, vault paths, or personal_finance.db
- Fixed-string scan for common token/private-key markers: no matches
- git check-ignore confirms AGENTS.md and .hermes/* are ignored
- php artisan expense:sync --dry-run --force fails cleanly when no db path is configured

## Manual Review Checklist
- Review README.md for generic setup/sync paths only.
- Review .gitignore and confirm AGENTS.md and .hermes/ stay local-only.
- Review config/sync.php and ExpenseSyncService.php for no personal default paths.
- Confirm CI passes.

Closes #39
