### PR TITLE
Add public repo templates and docs skeleton

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug Report
+description: Report something that is broken or behaving unexpectedly.
+title: "Bug: "
+labels: ["type:task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Keep examples synthetic and do not attach private financial data.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken?
+      placeholder: "Example: Transaction filter loses the selected account after pagination."
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What happens instead?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps To Reproduce
+      description: List the smallest set of steps that reproduces the issue.
+      placeholder: |
+        1. Go to Transactions
+        2. Filter by account
+        3. Click page 2
+        4. Observe the filter state
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected Area
+      options:
+        - Transactions
+        - Accounts
+        - Categories
+        - Budgets
+        - Dashboard
+        - Sync
+        - Statement import
+        - Chat / AI
+        - Documentation / workflow
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - P0 - blocks safe use or corrupts data
+        - P1 - core workflow broken
+        - P2 - important but has workaround
+        - P3 - polish or minor issue
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, OS, PHP/Node versions, or deployment target if relevant.
+      placeholder: "Local WSL Ubuntu, PHP 8.4, Node 22, Chrome"
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Screenshots / Logs
+      description: Add screenshots, console output, or logs. Remove private paths, tokens, and real account data first.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security or private data concern
+    url: https://github.com/aniketan/expense-manager/security
+    about: Please do not post secrets, private databases, bank statements, or real financial data in public issues.

--- a/.github/ISSUE_TEMPLATE/feature_task.yml
+++ b/.github/ISSUE_TEMPLATE/feature_task.yml
@@ -1,0 +1,69 @@
+name: Feature / Task
+description: Propose a feature, workflow improvement, or implementation task.
+title: "Task: "
+labels: ["type:task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for product tasks, workflow improvements, and implementation slices.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user or engineering problem are we solving?
+    validations:
+      required: true
+  - type: textarea
+    id: user_value
+    attributes:
+      label: User Value
+      description: Why does this matter for Expense Manager?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Chat entry
+        - Category mapping
+        - Statement import
+        - Transactions / audit trail
+        - Sync / data integrity
+        - Dashboard / UX
+        - Portfolio / docs
+        - Workflow / CI
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Proposed Scope
+      description: What should be included, and what should stay out of scope?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Checklist for implementation and review.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification Plan
+      description: Tests, build commands, manual checks, screenshots, or data checks expected for this task.
+      placeholder: |
+        - [ ] npm run build
+        - [ ] composer test
+  - type: textarea
+    id: notes
+    attributes:
+      label: Implementation Notes
+      description: Relevant files, constraints, risks, or follow-up work.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Context
+
+Closes #
+
+What problem does this PR solve?
+
+## Changes
+
+- TODO
+
+## Verification
+
+- [ ] `npm run build`
+- [ ] `composer test`
+- [ ] Targeted tests or manual checks:
+
+## Manual Review
+
+- [ ] Scope matches the linked issue.
+- [ ] No private paths, secrets, real financial data, or machine-specific files are included.
+- [ ] Screenshots or notes are added for UI changes.
+- [ ] Risks and follow-up work are called out below.
+
+## Risks / Notes
+
+- TODO

--- a/README.md
+++ b/README.md
@@ -1,6 +1,29 @@
 # Expense Manager
 
-Expense Manager is a Laravel and React application for tracking personal finances, managing accounts, and reviewing spending patterns.
+Expense Manager is a single-user personal finance app built with Laravel, Inertia, and React. The long-term product direction is chat-first money management: fast expense capture, reliable category mapping, statement import cleanup, and auditable balances.
+
+The public `main` branch currently contains the foundation: accounts, categories, transactions, budgets, dashboard analytics, external SQLite sync, CI, and the portfolio/docs workflow. Chat entry, AI-assisted categorization, and statement import reconciliation are active product lanes and should be treated as roadmap/WIP until merged.
+
+## Stack
+
+- Laravel 13
+- PHP 8.4 in CI
+- Inertia Laravel 3
+- React 19
+- Vite 7
+- Tailwind CSS 4
+- Bootstrap 5
+- SQLite by default for local development and CI
+- Prism PHP is available for future AI integration work
+
+## Core Workflows
+
+- Manage accounts with opening and current balances.
+- Manage parent and child categories for income and expense tracking.
+- Create, edit, filter, and review transactions.
+- Track budgets by category and period.
+- View dashboard and analytics summaries.
+- Sync data from a private external SQLite database with `php artisan expense:sync`.
 
 ## Local Setup
 
@@ -17,11 +40,22 @@ composer test
 
 ## Development
 
-Run the backend and frontend during local development:
+Run the backend, queue worker, and Vite dev server together:
 
 ```bash
 composer run dev
 ```
+
+## Verification
+
+Use these commands before opening or merging a PR when practical:
+
+```bash
+npm run build
+composer test
+```
+
+GitHub Actions also runs the frontend build, migrations, and PHP test suite on pull requests to `main`.
 
 ## Expense Sync
 
@@ -33,4 +67,16 @@ php artisan expense:sync --db-path="/path/to/private/expense-data.sqlite"
 php artisan expense:sync --db-path="/path/to/private/expense-data.sqlite" --force
 ```
 
-Never commit local `.env` files, private databases, bank statements, or machine-specific assistant context.
+You can also set `EXTERNAL_DB_PATH` in your local `.env`. Do not commit local `.env` files, private databases, bank statements, machine-specific assistant context, or real financial data.
+
+## Documentation
+
+- [Architecture](docs/architecture.md)
+- [AI Tools](docs/ai-tools.md)
+- [Statement Import](docs/statement-import.md)
+- [AI-Assisted Development](docs/ai-assisted-development.md)
+- [Roadmap](docs/roadmap.md)
+
+## Project Status
+
+Expense Manager is in active development. The current priority is the core money-entry workflow: chat-based capture, trustworthy categorization, statement import cleanup, and balance auditability. Broader dashboard and portfolio polish are intentionally secondary until that core workflow is reliable.

--- a/docs/ai-assisted-development.md
+++ b/docs/ai-assisted-development.md
@@ -1,0 +1,49 @@
+# AI-Assisted Development
+
+Expense Manager uses AI-assisted development as a disciplined engineering workflow, not as a replacement for review. GitHub remains the public source of truth for issues, pull requests, review, and CI.
+
+## Working Model
+
+- GitHub issues define the visible task scope and acceptance criteria.
+- GitHub Project tracks status across planning, ready, in progress, review, and done.
+- AI-assisted work happens in focused implementation lanes.
+- Private planning notes remain long-term product memory and planning context.
+- The repo remains implementation truth.
+
+## Branching
+
+- Use short-lived branches with the `codex/` prefix for AI-assisted work.
+- Keep each branch tied to a single issue or tight issue cluster.
+- Use isolated worktrees when the main local checkout has unrelated WIP.
+
+## Pull Requests
+
+Each PR should include:
+
+- Linked issue.
+- Summary of changes.
+- Verification commands and results.
+- Risks, warnings, or known limitations.
+- Screenshots or notes for UI-facing changes.
+
+The human maintainer should review the diff and CI before merge. Squash merge is preferred for small focused branches so `main` keeps a clean portfolio-grade history.
+
+## Privacy Rules
+
+Never commit:
+
+- `.env` files.
+- Private SQLite databases.
+- Bank statements or real financial exports.
+- Machine-specific assistant context such as local agent files.
+- Personal local paths, tokens, account numbers, UPI IDs, or other sensitive identifiers.
+
+## Review Rhythm
+
+1. Clarify acceptance criteria on the issue.
+2. Create a scoped branch/worktree.
+3. Implement only the approved scope.
+4. Run practical tests/builds.
+5. Open a draft or ready PR with verification notes.
+6. Human reviewer checks files changed, CI, privacy, and behavior.
+7. Merge after review, then update the board/notes.

--- a/docs/ai-tools.md
+++ b/docs/ai-tools.md
@@ -1,0 +1,35 @@
+# AI Tools
+
+Expense Manager's product direction is chat-first personal finance. The AI layer is intended to help users capture expenses quickly, classify transactions reliably, and perform safe workflow actions through explicit tools.
+
+## Current Status
+
+The public `main` branch includes the app foundation and Prism PHP dependency, but the chat controller, agent tools, and AI categorization workflows are not treated as complete public features yet. Active AI work should be tracked in dedicated issues and PRs before it is described as shipped.
+
+## Intended AI Responsibilities
+
+- Parse natural-language expense entries into structured transaction drafts.
+- Suggest category and subcategory mappings with confidence and fallback behavior.
+- Flag transactions that need more detail instead of guessing silently.
+- Support controlled actions such as creating transactions or running sync only when the user intent is clear.
+- Keep real financial data out of public fixtures, docs, and issue examples.
+
+## Tool Boundary Principles
+
+- AI should prepare or propose changes before mutating money data.
+- Any balance-impacting action should be auditable through normal transaction records.
+- Category IDs and account IDs should be resolved from the database, not invented by the model.
+- Low-confidence classification should produce a review state, not a hidden best guess.
+- Tool results should include enough context for debugging without leaking private local paths or real account data.
+
+## Planned Work
+
+- Chat-based transaction entry.
+- AI category mapping with parent/subcategory accuracy.
+- Statement row categorization assistance.
+- Agent tools for safe sync/action workflows.
+- Evaluation fixtures that use synthetic data only.
+
+## Verification Expectations
+
+AI changes should include focused tests for parsing, category resolution, fallback behavior, and unsafe-action prevention. UI changes should include a manual review note or screenshot when relevant.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,47 @@
+# Architecture
+
+Expense Manager is a Laravel 13 application with an Inertia/React frontend. The public `main` branch is a single-user personal finance app focused on accounts, categories, transactions, budgets, dashboard analytics, and external SQLite sync.
+
+## Application Shape
+
+- Laravel routes live in `routes/web.php`.
+- Server-rendered page responses are handled through Inertia.
+- React pages live under `resources/js/Pages`.
+- Shared frontend bootstrapping lives in `resources/js/app.jsx` and `resources/js/bootstrap.js`.
+- Core domain models are `Account`, `Category`, `Transaction`, and `Budget`.
+- Local development and CI use SQLite by default.
+
+## Main Data Model
+
+- `accounts` store balance-bearing places such as savings, credit card, cash, current, and investment accounts.
+- `categories` support parent and child category hierarchies.
+- `transactions` belong to an account and category, and store type, amount, date, description, payment method, reference number, tags, and location.
+- `budgets` belong to categories and track spend within a configured date range.
+
+## Request Flow
+
+1. A browser request hits Laravel routes in `routes/web.php`.
+2. A controller loads Eloquent models and prepares page props.
+3. Inertia renders the matching React page.
+4. Form submissions return through Laravel validation and redirects.
+
+## Balance Updates
+
+`Transaction` model events update account balances when transactions are created, updated, or deleted. Income adds to the account balance, expenses subtract from it, and transfer handling creates paired transaction entries through `TransactionController`.
+
+`Account::recalculateBalance()` can rebuild an account balance from its opening balance and related transactions when needed.
+
+## External Sync
+
+`php artisan expense:sync` imports categories, accounts, and transactions from a private external SQLite database. The external database path must be supplied with `--db-path` or `EXTERNAL_DB_PATH`. Private databases and local paths must stay out of version control.
+
+## CI
+
+GitHub Actions runs on pushes and pull requests to `main`. The workflow installs PHP and Node dependencies, builds frontend assets, prepares SQLite, runs migrations, and executes `composer test`.
+
+## Current Limitations
+
+- The public `main` branch does not yet include the active chat-first workflow.
+- Statement import and reconciliation are active WIP lanes and are documented separately as roadmap work.
+- There is no public multi-user/auth workflow in the current branch.
+- Audit history beyond transaction timestamps is not yet a complete product surface.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,47 @@
+# Roadmap
+
+Expense Manager is in active development. The roadmap is intentionally centered on the core money-entry workflow before dashboard polish or broad product expansion.
+
+## Current Priority
+
+1. Stabilize statement import and reconciliation WIP.
+2. Make chat-based expense entry reliable.
+3. Improve category mapping quality.
+4. Make transactions and balances easier to audit.
+5. Keep public repo workflow, CI, and docs professional.
+
+## Product Lanes
+
+### Statement Import + Reconciliation
+
+Clean up statement parsing, review behavior, duplicate detection, reconciliation, and tests so imported rows can be trusted.
+
+### Chat Entry + Agent Tools
+
+Build fast chat-based transaction creation and safe agent tools for user-approved actions.
+
+### Category Mapping + Classifier
+
+Improve parent/subcategory accuracy, fallback behavior, and statement row categorization.
+
+### Transactions + Audit Trail
+
+Improve transaction list/edit/export behavior, balance correctness, audit views, and missing-detail workflows.
+
+### Sync + Data Integrity
+
+Harden external database sync, anomaly checks, duplicate cleanup, and balance mismatch detection.
+
+### UX / Dashboard / Product Notes
+
+Polish monthly review and dashboard experiences after the core entry/import/audit loop is dependable.
+
+## Portfolio Standard
+
+The public repository should show professional engineering habits:
+
+- Clear issue scope and acceptance criteria.
+- Focused PRs with review notes.
+- Passing CI.
+- Accurate docs that do not overclaim unfinished features.
+- Synthetic test data and no private local artifacts.

--- a/docs/statement-import.md
+++ b/docs/statement-import.md
@@ -1,0 +1,35 @@
+# Statement Import
+
+Statement import is a priority product lane, but it is not part of the public `main` branch as a finished workflow yet. This document defines the intended shape so implementation PRs can stay aligned.
+
+## Goal
+
+Imported bank or card statements should become clean, reviewable transaction candidates without exposing private financial data in the repository.
+
+## Intended Flow
+
+1. Upload or provide a statement file.
+2. Parse rows into normalized candidate transactions.
+3. Detect duplicates and already-imported rows.
+4. Match statement rows to existing transactions when possible.
+5. Suggest categories and mark uncertain rows for review.
+6. Let the user approve, skip, or correct rows before import.
+7. Preserve enough metadata to audit how imported transactions were created.
+
+## Reconciliation Principles
+
+- Matching should rely on stable keys such as date, amount, account, description normalization, and reference data when available.
+- Duplicate detection should prefer false negatives over silent false positives for money data.
+- Balance mismatches should be visible and explainable.
+- Manual corrections should be preserved rather than overwritten by later automation.
+
+## Data Privacy
+
+- Test fixtures must use synthetic names, accounts, descriptions, references, and balances.
+- Real bank statements, account numbers, UPI IDs, private paths, and local exports must not be committed.
+- Public docs should describe behavior without including real financial examples.
+
+## Current Limitations
+
+- Statement parser, reconciliation, and review UI work is tracked in active WIP outside the public `main` baseline.
+- The docs should be updated as those implementation slices merge.


### PR DESCRIPTION
## Context

Closes #40.

This PR turns the approved #40 acceptance criteria into public-facing repository workflow docs and templates, while keeping the active product WIP out of scope.

## Changes

- Adds a PR template with context, change summary, verification, manual review, and risk sections.
- Adds GitHub issue forms for bug reports and feature/tasks.
- Expands the README with stack, setup, verification, sync, docs, and project status sections.
- Adds docs skeleton pages for architecture, AI tools, statement import, AI-assisted development, and roadmap.
- Marks chat, AI categorization, and statement import reconciliation as active roadmap/WIP instead of shipped behavior.

## Verification

- [x] `npm run build`
- [x] `composer test`
- [x] `git diff --cached --check`
- [x] Privacy scan for local/private path markers across README, `.github`, and `docs`

## Risks / Notes

- `npm run build` passes with the existing Vite chunk-size warning for the app bundle.
- This PR intentionally does not change application logic, statement import WIP, chat WIP, category mapping, transaction behavior, or sync behavior.