### PR TITLE
[codex] Fix transaction form validation feedback

### DIFF
--- a/resources/js/Components/FormErrorSummary.jsx
+++ b/resources/js/Components/FormErrorSummary.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function FormErrorSummary({ errorEntries, errorLabels }) {
+    if (!errorEntries || errorEntries.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="alert alert-danger" role="alert" aria-live="polite">
+            <div className="fw-semibold mb-2">
+                Please fix the highlighted fields before saving.
+            </div>
+            <ul className="mb-0 ps-3">
+                {errorEntries.map(([field, message]) => (
+                    <li key={field}>
+                        <strong>{errorLabels[field] || field}:</strong> {message}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}

--- a/resources/js/Pages/Transactions/Create.jsx
+++ b/resources/js/Pages/Transactions/Create.jsx
@@ -1,16 +1,22 @@
 import React, { useState } from 'react';
 import { Head, Link, useForm } from '@inertiajs/react';
 import BootstrapLayout from '../../Layouts/BootstrapLayout';
+import FormErrorSummary from '../../Components/FormErrorSummary';
 import {
-    validateAmount,
     validateDate,
-    validateTime,
     validateDescription,
     sanitizeText,
     validateTags,
     handleAmountInput,
     getMaxDate,
-    getMinDate
+    getMinDate,
+    TRANSACTION_ERROR_ORDER,
+    clearValidationFieldError,
+    clearValidationFieldErrors,
+    getErrorEntries,
+    getTransactionErrorLabels,
+    setValidationFieldError,
+    validateTransactionForm,
 } from '../../utils/inputValidation';
 
 export default function Create({ categories, accounts }) {
@@ -38,48 +44,16 @@ export default function Create({ categories, accounts }) {
         transaction_type: 'expense'
     });
 
-    const errorLabels = {
-        transaction_date: 'Date',
-        transaction_time: 'Time',
-        amount: 'Amount',
-        account_id: transactionType === 'transfer' ? 'From Account' : 'Account',
-        transfer_to_account_id: 'To Account',
-        payment_method: 'Payment Method',
-        category: 'Category',
-        category_id: transactionType === 'income' ? 'Income Category' : 'Subcategory',
-        description: 'Description',
-        tags: 'Tags',
-        transfer: 'Transfer',
-    };
-
-    const errorOrder = [
-        'transaction_date',
-        'transaction_time',
-        'amount',
-        'account_id',
-        'transfer_to_account_id',
-        'payment_method',
-        'category',
-        'category_id',
-        'description',
-        'tags',
-        'transfer',
-    ];
-
-    const combinedErrors = { ...validationErrors, ...errors };
-    const errorEntries = [
-        ...errorOrder
-            .filter((field) => combinedErrors[field])
-            .map((field) => [field, combinedErrors[field]]),
-        ...Object.entries(combinedErrors)
-            .filter(([field, message]) => message && !errorOrder.includes(field)),
-    ];
+    const errorLabels = getTransactionErrorLabels(transactionType);
+    const errorEntries = getErrorEntries(validationErrors, errors, TRANSACTION_ERROR_ORDER);
 
     const setFieldError = (field, message) => {
-        setValidationErrors((current) => ({ ...current, [field]: message || null }));
+        setValidationFieldError(setValidationErrors, field, message);
     };
 
-    const clearFieldError = (field) => setFieldError(field, null);
+    const clearFieldError = (field) => {
+        clearValidationFieldError(setValidationErrors, field);
+    };
 
     // Get parent categories (where parent_id is null)
     const parentCategories = categories.filter(cat => cat.parent_id === null);
@@ -101,7 +75,7 @@ export default function Create({ categories, accounts }) {
         const subs = getSubcategories(parentCategoryId);
         setSubcategories(subs);
         if (!subs || subs.length === 0) {
-            alert('No subcategories found for the selected category. Please pick a different category.');
+            setFieldError('category', 'No subcategories found for the selected category. Please pick a different category.');
             setSelectedCategory('');
             setSubcategories([]);
         }
@@ -123,14 +97,13 @@ export default function Create({ categories, accounts }) {
         setSelectedCategory('');
         setSubcategories([]);
         setData('category_id', '');
-        setValidationErrors((current) => ({
-            ...current,
-            category: null,
-            category_id: null,
-            payment_method: null,
-            transfer_to_account_id: null,
-            transfer: null,
-        }));
+        clearValidationFieldErrors(setValidationErrors, [
+            'category',
+            'category_id',
+            'payment_method',
+            'transfer_to_account_id',
+            'transfer',
+        ]);
 
         // Auto-select category for income
         if (type === 'income' && incomeCategory) {
@@ -211,65 +184,16 @@ export default function Create({ categories, accounts }) {
     const handleSubmit = (e) => {
         e.preventDefault();
 
-        const nextErrors = {};
-
-        const amountValidation = validateAmount(data.amount, false, 999999999.99);
-        if (!amountValidation.isValid) {
-            nextErrors.amount = amountValidation.error;
-        }
-
-        const dateValidation = validateDate(data.transaction_date, false, 10,data.transaction_time);
-        if (!dateValidation.isValid) {
-            nextErrors.transaction_date = dateValidation.error;
-        }
-
-        if (data.transaction_time) {
-            const timeValidation = validateTime(data.transaction_time);
-            if (!timeValidation.isValid) {
-                nextErrors.transaction_time = timeValidation.error;
-            }
-        }
-
-        if (!data.account_id) {
-            nextErrors.account_id = 'Account is required';
-        }
-
-        if (transactionType !== 'transfer') {
-            if (!data.payment_method) {
-                nextErrors.payment_method = 'Payment method is required';
-            }
-            if (transactionType !== 'income' && !selectedCategory) {
-                nextErrors.category = 'Category is required';
-            }
-            if (!data.category_id) {
-                nextErrors.category_id = transactionType === 'income'
-                    ? 'Income category is required'
-                    : 'Subcategory is required';
-            }
-        }
-
-        if (transactionType === 'transfer') {
-            if (!data.transfer_to_account_id) {
-                nextErrors.transfer_to_account_id = 'Destination account is required';
-            }
-            if (data.account_id && data.account_id === data.transfer_to_account_id) {
-                nextErrors.transfer = 'Source and destination accounts must be different';
-            }
-        }
-
-        if (data.description) {
-            const descValidation = validateDescription(data.description, 1000, false);
-            if (!descValidation.isValid) {
-                nextErrors.description = descValidation.error;
-            }
-        }
-
-        if (data.tags) {
-            const tagsValidation = validateTags(data.tags, 10, 30);
-            if (!tagsValidation.isValid) {
-                nextErrors.tags = tagsValidation.error;
-            }
-        }
+        const nextErrors = validateTransactionForm(data, {
+            transactionType,
+            selectedCategory,
+            dateField: 'transaction_date',
+            includeTimeInDate: true,
+            maxPastYears: 10,
+            maxAmount: 999999999.99,
+            tagsMax: 10,
+            tagMaxLength: 30,
+        });
 
         setValidationErrors(nextErrors);
 
@@ -308,20 +232,7 @@ export default function Create({ categories, accounts }) {
                         </div>
                         <div className="card-body">
                             <form onSubmit={handleSubmit} noValidate>
-                                {errorEntries.length > 0 && (
-                                    <div className="alert alert-danger" role="alert" aria-live="polite">
-                                        <div className="fw-semibold mb-2">
-                                            Please fix the highlighted fields before saving.
-                                        </div>
-                                        <ul className="mb-0 ps-3">
-                                            {errorEntries.map(([field, message]) => (
-                                                <li key={field}>
-                                                    <strong>{errorLabels[field] || field}:</strong> {message}
-                                                </li>
-                                            ))}
-                                        </ul>
-                                    </div>
-                                )}
+                                <FormErrorSummary errorEntries={errorEntries} errorLabels={errorLabels} />
 
                                 {/* Transaction Type - Moved to top */}
                                 <div className="row mb-4">

--- a/resources/js/Pages/Transactions/Create.jsx
+++ b/resources/js/Pages/Transactions/Create.jsx
@@ -5,6 +5,7 @@ import {
     validateAmount,
     validateDate,
     validateTime,
+    validateDescription,
     sanitizeText,
     validateTags,
     handleAmountInput,
@@ -37,6 +38,49 @@ export default function Create({ categories, accounts }) {
         transaction_type: 'expense'
     });
 
+    const errorLabels = {
+        transaction_date: 'Date',
+        transaction_time: 'Time',
+        amount: 'Amount',
+        account_id: transactionType === 'transfer' ? 'From Account' : 'Account',
+        transfer_to_account_id: 'To Account',
+        payment_method: 'Payment Method',
+        category: 'Category',
+        category_id: transactionType === 'income' ? 'Income Category' : 'Subcategory',
+        description: 'Description',
+        tags: 'Tags',
+        transfer: 'Transfer',
+    };
+
+    const errorOrder = [
+        'transaction_date',
+        'transaction_time',
+        'amount',
+        'account_id',
+        'transfer_to_account_id',
+        'payment_method',
+        'category',
+        'category_id',
+        'description',
+        'tags',
+        'transfer',
+    ];
+
+    const combinedErrors = { ...validationErrors, ...errors };
+    const errorEntries = [
+        ...errorOrder
+            .filter((field) => combinedErrors[field])
+            .map((field) => [field, combinedErrors[field]]),
+        ...Object.entries(combinedErrors)
+            .filter(([field, message]) => message && !errorOrder.includes(field)),
+    ];
+
+    const setFieldError = (field, message) => {
+        setValidationErrors((current) => ({ ...current, [field]: message || null }));
+    };
+
+    const clearFieldError = (field) => setFieldError(field, null);
+
     // Get parent categories (where parent_id is null)
     const parentCategories = categories.filter(cat => cat.parent_id === null);
 
@@ -62,11 +106,14 @@ export default function Create({ categories, accounts }) {
             setSubcategories([]);
         }
         setData('category_id', '');
+        clearFieldError('category_id');
     };
 
     const handleCategoryChange = (e) => {
         const parentCategoryId = parseInt(e.target.value);
         setSelectedCategory(parentCategoryId);
+        clearFieldError('category');
+        clearFieldError('category_id');
         updateSubcategories(parentCategoryId);
     };
 
@@ -76,6 +123,14 @@ export default function Create({ categories, accounts }) {
         setSelectedCategory('');
         setSubcategories([]);
         setData('category_id', '');
+        setValidationErrors((current) => ({
+            ...current,
+            category: null,
+            category_id: null,
+            payment_method: null,
+            transfer_to_account_id: null,
+            transfer: null,
+        }));
 
         // Auto-select category for income
         if (type === 'income' && incomeCategory) {
@@ -94,7 +149,7 @@ export default function Create({ categories, accounts }) {
         handleAmountInput(e, (value) => {
             setData('amount', value);
             if (validationErrors.amount) {
-                setValidationErrors({ ...validationErrors, amount: null });
+                clearFieldError('amount');
             }
         });
     };
@@ -106,9 +161,9 @@ export default function Create({ categories, accounts }) {
 
         const validation = validateDate(value, false, 10);
         if (!validation.isValid) {
-            setValidationErrors({ ...validationErrors, transaction_date: validation.error });
+            setFieldError('transaction_date', validation.error);
         } else {
-            setValidationErrors({ ...validationErrors, transaction_date: null });
+            clearFieldError('transaction_date');
         }
     };
 
@@ -117,9 +172,9 @@ export default function Create({ categories, accounts }) {
         const validation = validateDescription(e.target.value, 1000, false);
         setData('description', validation.value);
         if (!validation.isValid) {
-            setValidationErrors({ ...validationErrors, description: validation.error });
+            setFieldError('description', validation.error);
         } else {
-            setValidationErrors({ ...validationErrors, description: null });
+            clearFieldError('description');
         }
     };
 
@@ -129,9 +184,9 @@ export default function Create({ categories, accounts }) {
         setData('tags', validation.value);
 
         if (!validation.isValid) {
-            setValidationErrors({ ...validationErrors, tags: validation.error });
+            setFieldError('tags', validation.error);
         } else {
-            setValidationErrors({ ...validationErrors, tags: null });
+            clearFieldError('tags');
         }
     };
 
@@ -156,45 +211,70 @@ export default function Create({ categories, accounts }) {
     const handleSubmit = (e) => {
         e.preventDefault();
 
-        // Validate amount
+        const nextErrors = {};
+
         const amountValidation = validateAmount(data.amount, false, 999999999.99);
         if (!amountValidation.isValid) {
-            setValidationErrors({ ...validationErrors, amount: amountValidation.error });
-            return;
+            nextErrors.amount = amountValidation.error;
         }
 
-        // Validate date
         const dateValidation = validateDate(data.transaction_date, false, 10,data.transaction_time);
         if (!dateValidation.isValid) {
-            setValidationErrors({ ...validationErrors, transaction_date: dateValidation.error });
-            return;
+            nextErrors.transaction_date = dateValidation.error;
         }
 
-        // Validate time if provided
         if (data.transaction_time) {
             const timeValidation = validateTime(data.transaction_time);
             if (!timeValidation.isValid) {
-                setValidationErrors({ ...validationErrors, transaction_time: timeValidation.error });
-                return;
+                nextErrors.transaction_time = timeValidation.error;
             }
         }
 
-        // Validate category for non-transfer
-        if (transactionType !== 'transfer' && !data.category_id) {
-            alert('Please select a category');
-            return;
+        if (!data.account_id) {
+            nextErrors.account_id = 'Account is required';
         }
 
-        // Validate transfer accounts
+        if (transactionType !== 'transfer') {
+            if (!data.payment_method) {
+                nextErrors.payment_method = 'Payment method is required';
+            }
+            if (transactionType !== 'income' && !selectedCategory) {
+                nextErrors.category = 'Category is required';
+            }
+            if (!data.category_id) {
+                nextErrors.category_id = transactionType === 'income'
+                    ? 'Income category is required'
+                    : 'Subcategory is required';
+            }
+        }
+
         if (transactionType === 'transfer') {
             if (!data.transfer_to_account_id) {
-                alert('Please select destination account');
-                return;
+                nextErrors.transfer_to_account_id = 'Destination account is required';
             }
-            if (data.account_id === data.transfer_to_account_id) {
-                alert('Source and destination accounts must be different');
-                return;
+            if (data.account_id && data.account_id === data.transfer_to_account_id) {
+                nextErrors.transfer = 'Source and destination accounts must be different';
             }
+        }
+
+        if (data.description) {
+            const descValidation = validateDescription(data.description, 1000, false);
+            if (!descValidation.isValid) {
+                nextErrors.description = descValidation.error;
+            }
+        }
+
+        if (data.tags) {
+            const tagsValidation = validateTags(data.tags, 10, 30);
+            if (!tagsValidation.isValid) {
+                nextErrors.tags = tagsValidation.error;
+            }
+        }
+
+        setValidationErrors(nextErrors);
+
+        if (Object.keys(nextErrors).length > 0) {
+            return;
         }
 
         post('/transactions');
@@ -227,7 +307,22 @@ export default function Create({ categories, accounts }) {
                             </h5>
                         </div>
                         <div className="card-body">
-                            <form onSubmit={handleSubmit}>
+                            <form onSubmit={handleSubmit} noValidate>
+                                {errorEntries.length > 0 && (
+                                    <div className="alert alert-danger" role="alert" aria-live="polite">
+                                        <div className="fw-semibold mb-2">
+                                            Please fix the highlighted fields before saving.
+                                        </div>
+                                        <ul className="mb-0 ps-3">
+                                            {errorEntries.map(([field, message]) => (
+                                                <li key={field}>
+                                                    <strong>{errorLabels[field] || field}:</strong> {message}
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </div>
+                                )}
+
                                 {/* Transaction Type - Moved to top */}
                                 <div className="row mb-4">
                                     <div className="col-12">
@@ -355,10 +450,14 @@ export default function Create({ categories, accounts }) {
                                             {transactionType === 'transfer' ? 'From Account' : 'Account'} <span className="text-danger">*</span>
                                         </label>
                                         <select
-                                            className={`form-select ${errors.account_id ? 'is-invalid' : ''}`}
+                                            className={`form-select ${errors.account_id || validationErrors.account_id ? 'is-invalid' : ''}`}
                                             id="account"
                                             value={data.account_id}
-                                            onChange={e => setData('account_id', e.target.value)}
+                                            onChange={e => {
+                                                setData('account_id', e.target.value);
+                                                clearFieldError('account_id');
+                                                clearFieldError('transfer');
+                                            }}
                                             required
                                         >
                                             <option value="">Select Account</option>
@@ -368,7 +467,11 @@ export default function Create({ categories, accounts }) {
                                                 </option>
                                             ))}
                                         </select>
-                                        {errors.account_id && <div className="invalid-feedback">{errors.account_id}</div>}
+                                        {(errors.account_id || validationErrors.account_id) && (
+                                            <div className="invalid-feedback">
+                                                {errors.account_id || validationErrors.account_id}
+                                            </div>
+                                        )}
                                     </div>
                                     {transactionType === 'transfer' ? (
                                         <div className="col-md-6">
@@ -376,10 +479,14 @@ export default function Create({ categories, accounts }) {
                                                 To Account <span className="text-danger">*</span>
                                             </label>
                                             <select
-                                                className={`form-select ${errors.transfer_to_account_id ? 'is-invalid' : ''}`}
+                                                className={`form-select ${errors.transfer_to_account_id || validationErrors.transfer_to_account_id || validationErrors.transfer ? 'is-invalid' : ''}`}
                                                 id="transfer_to_account"
                                                 value={data.transfer_to_account_id}
-                                                onChange={e => setData('transfer_to_account_id', e.target.value)}
+                                                onChange={e => {
+                                                    setData('transfer_to_account_id', e.target.value);
+                                                    clearFieldError('transfer_to_account_id');
+                                                    clearFieldError('transfer');
+                                                }}
                                                 required
                                             >
                                                 <option value="">Select Account</option>
@@ -389,7 +496,11 @@ export default function Create({ categories, accounts }) {
                                                     </option>
                                                 ))}
                                             </select>
-                                            {errors.transfer_to_account_id && <div className="invalid-feedback">{errors.transfer_to_account_id}</div>}
+                                            {(errors.transfer_to_account_id || validationErrors.transfer_to_account_id || validationErrors.transfer) && (
+                                                <div className="invalid-feedback">
+                                                    {errors.transfer_to_account_id || validationErrors.transfer_to_account_id || validationErrors.transfer}
+                                                </div>
+                                            )}
                                         </div>
                                     ) : (
                                         <div className="col-md-6">
@@ -397,10 +508,13 @@ export default function Create({ categories, accounts }) {
                                                 Payment Method <span className="text-danger">*</span>
                                             </label>
                                             <select
-                                                className={`form-select ${errors.payment_method ? 'is-invalid' : ''}`}
+                                                className={`form-select ${errors.payment_method || validationErrors.payment_method ? 'is-invalid' : ''}`}
                                                 id="payment_method"
                                                 value={data.payment_method}
-                                                onChange={e => setData('payment_method', e.target.value)}
+                                                onChange={e => {
+                                                    setData('payment_method', e.target.value);
+                                                    clearFieldError('payment_method');
+                                                }}
                                                 required
                                             >
                                                 <option value="">Select Method</option>
@@ -410,7 +524,11 @@ export default function Create({ categories, accounts }) {
                                                 <option value="Debit Card">Debit Card</option>
                                                 <option value="Cheque">Cheque</option>
                                             </select>
-                                            {errors.payment_method && <div className="invalid-feedback">{errors.payment_method}</div>}
+                                            {(errors.payment_method || validationErrors.payment_method) && (
+                                                <div className="invalid-feedback">
+                                                    {errors.payment_method || validationErrors.payment_method}
+                                                </div>
+                                            )}
                                         </div>
                                     )}
                                 </div>
@@ -452,10 +570,13 @@ export default function Create({ categories, accounts }) {
                                                     Income Category <span className="text-danger">*</span>
                                                 </label>
                                                 <select
-                                                    className="form-select"
+                                                    className={`form-select ${errors.category_id || validationErrors.category_id ? 'is-invalid' : ''}`}
                                                     id="subcategory"
                                                     value={data.category_id}
-                                                    onChange={e => setData('category_id', e.target.value)}
+                                                    onChange={e => {
+                                                        setData('category_id', e.target.value);
+                                                        clearFieldError('category_id');
+                                                    }}
                                                     required
                                                 >
                                                     <option value="">Select Income Category</option>
@@ -465,6 +586,11 @@ export default function Create({ categories, accounts }) {
                                                         </option>
                                                     ))}
                                                 </select>
+                                                {(errors.category_id || validationErrors.category_id) && (
+                                                    <div className="invalid-feedback">
+                                                        {errors.category_id || validationErrors.category_id}
+                                                    </div>
+                                                )}
                                             </div>
                                         ) : (
                                             /* Expense: Show both category and subcategory */
@@ -474,7 +600,7 @@ export default function Create({ categories, accounts }) {
                                                         Category <span className="text-danger">*</span>
                                                     </label>
                                                     <select
-                                                        className="form-select"
+                                                        className={`form-select ${validationErrors.category ? 'is-invalid' : ''}`}
                                                         id="category"
                                                         value={selectedCategory}
                                                         onChange={handleCategoryChange}
@@ -487,16 +613,22 @@ export default function Create({ categories, accounts }) {
                                                             </option>
                                                         ))}
                                                     </select>
+                                                    {validationErrors.category && (
+                                                        <div className="invalid-feedback">{validationErrors.category}</div>
+                                                    )}
                                                 </div>
                                                 <div className="col-md-6">
                                                     <label htmlFor="subcategory" className="form-label">
                                                         Subcategory <span className="text-danger">*</span>
                                                     </label>
                                                     <select
-                                                        className="form-select"
+                                                        className={`form-select ${errors.category_id || validationErrors.category_id ? 'is-invalid' : ''}`}
                                                         id="subcategory"
                                                         value={data.category_id}
-                                                        onChange={e => setData('category_id', e.target.value)}
+                                                        onChange={e => {
+                                                            setData('category_id', e.target.value);
+                                                            clearFieldError('category_id');
+                                                        }}
                                                         required
                                                         disabled={!selectedCategory}
                                                     >
@@ -507,6 +639,11 @@ export default function Create({ categories, accounts }) {
                                                             </option>
                                                         ))}
                                                     </select>
+                                                    {(errors.category_id || validationErrors.category_id) && (
+                                                        <div className="invalid-feedback">
+                                                            {errors.category_id || validationErrors.category_id}
+                                                        </div>
+                                                    )}
                                                 </div>
                                             </div>
                                         )}

--- a/resources/js/Pages/Transactions/Edit.jsx
+++ b/resources/js/Pages/Transactions/Edit.jsx
@@ -37,6 +37,59 @@ export default function Edit({ transaction, categories, accounts }) {
         transaction_type: transaction.transaction_type || 'expense'
     });
 
+    const errorLabels = {
+        expensed_date: 'Date',
+        transaction_time: 'Time',
+        amount: 'Amount',
+        account_id: transactionType === 'transfer' ? 'From Account' : 'Account',
+        transfer_to_account_id: 'To Account',
+        payment_method: 'Payment Method',
+        category: 'Category',
+        category_id: transactionType === 'income' ? 'Income Category' : 'Subcategory',
+        description: 'Description',
+        payee_payer: 'Payee/Payer',
+        reference_number: 'Reference Number',
+        tax: 'Tax Amount',
+        status: 'Status',
+        tags: 'Tags',
+        notes: 'Notes',
+        transfer: 'Transfer',
+    };
+
+    const errorOrder = [
+        'expensed_date',
+        'transaction_time',
+        'amount',
+        'account_id',
+        'transfer_to_account_id',
+        'payment_method',
+        'category',
+        'category_id',
+        'description',
+        'payee_payer',
+        'reference_number',
+        'tax',
+        'status',
+        'tags',
+        'notes',
+        'transfer',
+    ];
+
+    const combinedErrors = { ...validationErrors, ...errors };
+    const errorEntries = [
+        ...errorOrder
+            .filter((field) => combinedErrors[field])
+            .map((field) => [field, combinedErrors[field]]),
+        ...Object.entries(combinedErrors)
+            .filter(([field, message]) => message && !errorOrder.includes(field)),
+    ];
+
+    const setFieldError = (field, message) => {
+        setValidationErrors((current) => ({ ...current, [field]: message || null }));
+    };
+
+    const clearFieldError = (field) => setFieldError(field, null);
+
     // Get parent categories (where parent_id is null)
     const parentCategories = categories.filter(cat => cat.parent_id === null);
 
@@ -89,6 +142,8 @@ export default function Edit({ transaction, categories, accounts }) {
     const handleCategoryChange = (e) => {
         const parentCategoryId = parseInt(e.target.value);
         setSelectedCategory(parentCategoryId);
+        clearFieldError('category');
+        clearFieldError('category_id');
 
         if (parentCategoryId) {
             const subs = getSubcategories(parentCategoryId);
@@ -107,6 +162,14 @@ export default function Edit({ transaction, categories, accounts }) {
         setSelectedCategory('');
         setSubcategories([]);
         setData('category_id', '');
+        setValidationErrors((current) => ({
+            ...current,
+            category: null,
+            category_id: null,
+            payment_method: null,
+            transfer_to_account_id: null,
+            transfer: null,
+        }));
 
         // Auto-select category for income
         if (type === 'income' && incomeCategory) {
@@ -126,9 +189,9 @@ export default function Edit({ transaction, categories, accounts }) {
         handleAmountInput(e, setData, 'amount');
         const validation = validateAmount(e.target.value, false);
         if (!validation.isValid) {
-            setValidationErrors({ ...validationErrors, amount: validation.error });
+            setFieldError('amount', validation.error);
         } else {
-            setValidationErrors({ ...validationErrors, amount: null });
+            clearFieldError('amount');
         }
     };
 
@@ -137,9 +200,9 @@ export default function Edit({ transaction, categories, accounts }) {
         setData('expensed_date', e.target.value);
         const validation = validateDate(e.target.value);
         if (!validation.isValid) {
-            setValidationErrors({ ...validationErrors, expensed_date: validation.error });
+            setFieldError('expensed_date', validation.error);
         } else {
-            setValidationErrors({ ...validationErrors, expensed_date: null });
+            clearFieldError('expensed_date');
         }
     };
 
@@ -148,20 +211,20 @@ export default function Edit({ transaction, categories, accounts }) {
         setData('transaction_time', e.target.value);
         const validation = validateTime(e.target.value);
         if (!validation.isValid) {
-            setValidationErrors({ ...validationErrors, transaction_time: validation.error });
+            setFieldError('transaction_time', validation.error);
         } else {
-            setValidationErrors({ ...validationErrors, transaction_time: null });
+            clearFieldError('transaction_time');
         }
     };
 
     // Handle description with validation
     const handleDescriptionChange = (e) => {
-        const validation = validateDescription(e.target.value, 1000, true);
+        const validation = validateDescription(e.target.value, 1000, false);
         setData('description', validation.value);
         if (!validation.isValid) {
-            setValidationErrors({ ...validationErrors, description: validation.error });
+            setFieldError('description', validation.error);
         } else {
-            setValidationErrors({ ...validationErrors, description: null });
+            clearFieldError('description');
         }
     };
 
@@ -170,9 +233,9 @@ export default function Edit({ transaction, categories, accounts }) {
         const validation = validateTags(e.target.value, 10);
         setData('tags', validation.value);
         if (!validation.isValid) {
-            setValidationErrors({ ...validationErrors, tags: validation.error });
+            setFieldError('tags', validation.error);
         } else {
-            setValidationErrors({ ...validationErrors, tags: null });
+            clearFieldError('tags');
         }
     };
 
@@ -181,9 +244,9 @@ export default function Edit({ transaction, categories, accounts }) {
         const validation = validateDescription(e.target.value, 2000, false);
         setData('notes', validation.value);
         if (!validation.isValid) {
-            setValidationErrors({ ...validationErrors, notes: validation.error });
+            setFieldError('notes', validation.error);
         } else {
-            setValidationErrors({ ...validationErrors, notes: null });
+            clearFieldError('notes');
         }
     };
 
@@ -202,50 +265,75 @@ export default function Edit({ transaction, categories, accounts }) {
     const handleSubmit = (e) => {
         e.preventDefault();
 
-        // Validate amount
+        const nextErrors = {};
+
         const amountValidation = validateAmount(data.amount, false);
         if (!amountValidation.isValid) {
-            setValidationErrors({ ...validationErrors, amount: amountValidation.error });
-            return;
+            nextErrors.amount = amountValidation.error;
         }
 
-        // Validate date
         const dateValidation = validateDate(data.expensed_date);
         if (!dateValidation.isValid) {
-            setValidationErrors({ ...validationErrors, expensed_date: dateValidation.error });
-            return;
+            nextErrors.expensed_date = dateValidation.error;
         }
 
-        // Validate time
         const timeValidation = validateTime(data.transaction_time);
         if (!timeValidation.isValid) {
-            setValidationErrors({ ...validationErrors, transaction_time: timeValidation.error });
-            return;
+            nextErrors.transaction_time = timeValidation.error;
         }
 
-        // Validate description
-        const descValidation = validateDescription(data.description, 1000, true);
-        if (!descValidation.isValid) {
-            setValidationErrors({ ...validationErrors, description: descValidation.error });
-            return;
+        if (!data.account_id) {
+            nextErrors.account_id = 'Account is required';
         }
 
-        // Validate tags if provided
+        if (transactionType !== 'transfer') {
+            if (!data.payment_method) {
+                nextErrors.payment_method = 'Payment method is required';
+            }
+            if (transactionType !== 'income' && !selectedCategory) {
+                nextErrors.category = 'Category is required';
+            }
+            if (!data.category_id) {
+                nextErrors.category_id = transactionType === 'income'
+                    ? 'Income category is required'
+                    : 'Subcategory is required';
+            }
+        }
+
+        if (transactionType === 'transfer') {
+            if (!data.transfer_to_account_id) {
+                nextErrors.transfer_to_account_id = 'Destination account is required';
+            }
+            if (data.account_id && data.account_id === data.transfer_to_account_id) {
+                nextErrors.transfer = 'Source and destination accounts must be different';
+            }
+        }
+
+        if (data.description) {
+            const descValidation = validateDescription(data.description, 1000, false);
+            if (!descValidation.isValid) {
+                nextErrors.description = descValidation.error;
+            }
+        }
+
         if (data.tags) {
             const tagsValidation = validateTags(data.tags, 10);
             if (!tagsValidation.isValid) {
-                setValidationErrors({ ...validationErrors, tags: tagsValidation.error });
-                return;
+                nextErrors.tags = tagsValidation.error;
             }
         }
 
-        // Validate notes if provided
         if (data.notes) {
             const notesValidation = validateDescription(data.notes, 2000, false);
             if (!notesValidation.isValid) {
-                setValidationErrors({ ...validationErrors, notes: notesValidation.error });
-                return;
+                nextErrors.notes = notesValidation.error;
             }
+        }
+
+        setValidationErrors(nextErrors);
+
+        if (Object.keys(nextErrors).length > 0) {
+            return;
         }
 
         put(`/transactions/${transaction.id}`);
@@ -283,7 +371,22 @@ export default function Edit({ transaction, categories, accounts }) {
                             </h5>
                         </div>
                         <div className="card-body">
-                            <form onSubmit={handleSubmit}>
+                            <form onSubmit={handleSubmit} noValidate>
+                                {errorEntries.length > 0 && (
+                                    <div className="alert alert-danger" role="alert" aria-live="polite">
+                                        <div className="fw-semibold mb-2">
+                                            Please fix the highlighted fields before saving.
+                                        </div>
+                                        <ul className="mb-0 ps-3">
+                                            {errorEntries.map(([field, message]) => (
+                                                <li key={field}>
+                                                    <strong>{errorLabels[field] || field}:</strong> {message}
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </div>
+                                )}
+
                                 {/* Transaction Type - Moved to top */}
                                 <div className="row mb-4">
                                     <div className="col-12">
@@ -401,10 +504,14 @@ export default function Edit({ transaction, categories, accounts }) {
                                             {transactionType === 'transfer' ? 'From Account' : 'Account'} <span className="text-danger">*</span>
                                         </label>
                                         <select
-                                            className={`form-select ${errors.account_id ? 'is-invalid' : ''}`}
+                                            className={`form-select ${errors.account_id || validationErrors.account_id ? 'is-invalid' : ''}`}
                                             id="account"
                                             value={data.account_id}
-                                            onChange={e => setData('account_id', e.target.value)}
+                                            onChange={e => {
+                                                setData('account_id', e.target.value);
+                                                clearFieldError('account_id');
+                                                clearFieldError('transfer');
+                                            }}
                                             required
                                         >
                                             <option value="">Select Account</option>
@@ -414,7 +521,11 @@ export default function Edit({ transaction, categories, accounts }) {
                                                 </option>
                                             ))}
                                         </select>
-                                        {errors.account_id && <div className="invalid-feedback">{errors.account_id}</div>}
+                                        {(errors.account_id || validationErrors.account_id) && (
+                                            <div className="invalid-feedback">
+                                                {errors.account_id || validationErrors.account_id}
+                                            </div>
+                                        )}
                                     </div>
                                     {transactionType === 'transfer' ? (
                                         <div className="col-md-6">
@@ -422,10 +533,14 @@ export default function Edit({ transaction, categories, accounts }) {
                                                 To Account <span className="text-danger">*</span>
                                             </label>
                                             <select
-                                                className={`form-select ${errors.transfer_to_account_id ? 'is-invalid' : ''}`}
+                                                className={`form-select ${errors.transfer_to_account_id || validationErrors.transfer_to_account_id || validationErrors.transfer ? 'is-invalid' : ''}`}
                                                 id="transfer_to_account"
                                                 value={data.transfer_to_account_id}
-                                                onChange={e => setData('transfer_to_account_id', e.target.value)}
+                                                onChange={e => {
+                                                    setData('transfer_to_account_id', e.target.value);
+                                                    clearFieldError('transfer_to_account_id');
+                                                    clearFieldError('transfer');
+                                                }}
                                                 required
                                             >
                                                 <option value="">Select Account</option>
@@ -435,7 +550,11 @@ export default function Edit({ transaction, categories, accounts }) {
                                                     </option>
                                                 ))}
                                             </select>
-                                            {errors.transfer_to_account_id && <div className="invalid-feedback">{errors.transfer_to_account_id}</div>}
+                                            {(errors.transfer_to_account_id || validationErrors.transfer_to_account_id || validationErrors.transfer) && (
+                                                <div className="invalid-feedback">
+                                                    {errors.transfer_to_account_id || validationErrors.transfer_to_account_id || validationErrors.transfer}
+                                                </div>
+                                            )}
                                         </div>
                                     ) : (
                                         <div className="col-md-6">
@@ -443,10 +562,13 @@ export default function Edit({ transaction, categories, accounts }) {
                                                 Payment Method <span className="text-danger">*</span>
                                             </label>
                                             <select
-                                                className={`form-select ${errors.payment_method ? 'is-invalid' : ''}`}
+                                                className={`form-select ${errors.payment_method || validationErrors.payment_method ? 'is-invalid' : ''}`}
                                                 id="payment_method"
                                                 value={data.payment_method}
-                                                onChange={e => setData('payment_method', e.target.value)}
+                                                onChange={e => {
+                                                    setData('payment_method', e.target.value);
+                                                    clearFieldError('payment_method');
+                                                }}
                                                 required
                                             >
                                                 <option value="">Select Method</option>
@@ -457,7 +579,11 @@ export default function Edit({ transaction, categories, accounts }) {
                                                 <option value="Cash">Cash</option>
                                                 <option value="Cheque">Cheque</option>
                                             </select>
-                                            {errors.payment_method && <div className="invalid-feedback">{errors.payment_method}</div>}
+                                            {(errors.payment_method || validationErrors.payment_method) && (
+                                                <div className="invalid-feedback">
+                                                    {errors.payment_method || validationErrors.payment_method}
+                                                </div>
+                                            )}
                                         </div>
                                     )}
                                 </div>
@@ -499,10 +625,13 @@ export default function Edit({ transaction, categories, accounts }) {
                                                     Income Category <span className="text-danger">*</span>
                                                 </label>
                                                 <select
-                                                    className={`form-select ${errors.category_id ? 'is-invalid' : ''}`}
+                                                    className={`form-select ${errors.category_id || validationErrors.category_id ? 'is-invalid' : ''}`}
                                                     id="subcategory"
                                                     value={data.category_id}
-                                                    onChange={e => setData('category_id', e.target.value)}
+                                                    onChange={e => {
+                                                        setData('category_id', e.target.value);
+                                                        clearFieldError('category_id');
+                                                    }}
                                                     required
                                                 >
                                                     <option value="">Select Income Category</option>
@@ -512,7 +641,11 @@ export default function Edit({ transaction, categories, accounts }) {
                                                         </option>
                                                     ))}
                                                 </select>
-                                                {errors.category_id && <div className="invalid-feedback">{errors.category_id}</div>}
+                                                {(errors.category_id || validationErrors.category_id) && (
+                                                    <div className="invalid-feedback">
+                                                        {errors.category_id || validationErrors.category_id}
+                                                    </div>
+                                                )}
                                             </div>
                                         ) : (
                                             /* Expense: Show both category and subcategory */
@@ -522,7 +655,7 @@ export default function Edit({ transaction, categories, accounts }) {
                                                         Category <span className="text-danger">*</span>
                                                     </label>
                                                     <select
-                                                        className={`form-select ${errors.category ? 'is-invalid' : ''}`}
+                                                        className={`form-select ${errors.category || validationErrors.category ? 'is-invalid' : ''}`}
                                                         id="category"
                                                         value={selectedCategory}
                                                         onChange={handleCategoryChange}
@@ -535,17 +668,24 @@ export default function Edit({ transaction, categories, accounts }) {
                                                             </option>
                                                         ))}
                                                     </select>
-                                                    {errors.category && <div className="invalid-feedback">{errors.category}</div>}
+                                                    {(errors.category || validationErrors.category) && (
+                                                        <div className="invalid-feedback">
+                                                            {errors.category || validationErrors.category}
+                                                        </div>
+                                                    )}
                                                 </div>
                                                 <div className="col-md-6">
                                                     <label htmlFor="subcategory" className="form-label">
                                                         Subcategory <span className="text-danger">*</span>
                                                     </label>
                                                     <select
-                                                        className={`form-select ${errors.category_id ? 'is-invalid' : ''}`}
+                                                        className={`form-select ${errors.category_id || validationErrors.category_id ? 'is-invalid' : ''}`}
                                                         id="subcategory"
                                                         value={data.category_id}
-                                                        onChange={e => setData('category_id', e.target.value)}
+                                                        onChange={e => {
+                                                            setData('category_id', e.target.value);
+                                                            clearFieldError('category_id');
+                                                        }}
                                                         required
                                                         disabled={!selectedCategory}
                                                     >
@@ -556,7 +696,11 @@ export default function Edit({ transaction, categories, accounts }) {
                                                             </option>
                                                         ))}
                                                     </select>
-                                                    {errors.category_id && <div className="invalid-feedback">{errors.category_id}</div>}
+                                                    {(errors.category_id || validationErrors.category_id) && (
+                                                        <div className="invalid-feedback">
+                                                            {errors.category_id || validationErrors.category_id}
+                                                        </div>
+                                                    )}
                                                 </div>
                                             </div>
                                         )}

--- a/resources/js/Pages/Transactions/Edit.jsx
+++ b/resources/js/Pages/Transactions/Edit.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { Head, Link, useForm } from '@inertiajs/react';
 import BootstrapLayout from '../../Layouts/BootstrapLayout';
+import FormErrorSummary from '../../Components/FormErrorSummary';
 import {
-    validateAmount,
     validateDate,
     validateTime,
     validateDescription,
@@ -10,7 +10,14 @@ import {
     sanitizeText,
     handleAmountInput,
     getMaxDate,
-    getMinDate
+    getMinDate,
+    TRANSACTION_ERROR_ORDER,
+    clearValidationFieldError,
+    clearValidationFieldErrors,
+    getErrorEntries,
+    getTransactionErrorLabels,
+    setValidationFieldError,
+    validateTransactionForm,
 } from '../../utils/inputValidation';
 
 export default function Edit({ transaction, categories, accounts }) {
@@ -37,58 +44,16 @@ export default function Edit({ transaction, categories, accounts }) {
         transaction_type: transaction.transaction_type || 'expense'
     });
 
-    const errorLabels = {
-        expensed_date: 'Date',
-        transaction_time: 'Time',
-        amount: 'Amount',
-        account_id: transactionType === 'transfer' ? 'From Account' : 'Account',
-        transfer_to_account_id: 'To Account',
-        payment_method: 'Payment Method',
-        category: 'Category',
-        category_id: transactionType === 'income' ? 'Income Category' : 'Subcategory',
-        description: 'Description',
-        payee_payer: 'Payee/Payer',
-        reference_number: 'Reference Number',
-        tax: 'Tax Amount',
-        status: 'Status',
-        tags: 'Tags',
-        notes: 'Notes',
-        transfer: 'Transfer',
-    };
-
-    const errorOrder = [
-        'expensed_date',
-        'transaction_time',
-        'amount',
-        'account_id',
-        'transfer_to_account_id',
-        'payment_method',
-        'category',
-        'category_id',
-        'description',
-        'payee_payer',
-        'reference_number',
-        'tax',
-        'status',
-        'tags',
-        'notes',
-        'transfer',
-    ];
-
-    const combinedErrors = { ...validationErrors, ...errors };
-    const errorEntries = [
-        ...errorOrder
-            .filter((field) => combinedErrors[field])
-            .map((field) => [field, combinedErrors[field]]),
-        ...Object.entries(combinedErrors)
-            .filter(([field, message]) => message && !errorOrder.includes(field)),
-    ];
+    const errorLabels = getTransactionErrorLabels(transactionType);
+    const errorEntries = getErrorEntries(validationErrors, errors, TRANSACTION_ERROR_ORDER);
 
     const setFieldError = (field, message) => {
-        setValidationErrors((current) => ({ ...current, [field]: message || null }));
+        setValidationFieldError(setValidationErrors, field, message);
     };
 
-    const clearFieldError = (field) => setFieldError(field, null);
+    const clearFieldError = (field) => {
+        clearValidationFieldError(setValidationErrors, field);
+    };
 
     // Get parent categories (where parent_id is null)
     const parentCategories = categories.filter(cat => cat.parent_id === null);
@@ -162,14 +127,13 @@ export default function Edit({ transaction, categories, accounts }) {
         setSelectedCategory('');
         setSubcategories([]);
         setData('category_id', '');
-        setValidationErrors((current) => ({
-            ...current,
-            category: null,
-            category_id: null,
-            payment_method: null,
-            transfer_to_account_id: null,
-            transfer: null,
-        }));
+        clearValidationFieldErrors(setValidationErrors, [
+            'category',
+            'category_id',
+            'payment_method',
+            'transfer_to_account_id',
+            'transfer',
+        ]);
 
         // Auto-select category for income
         if (type === 'income' && incomeCategory) {
@@ -187,12 +151,7 @@ export default function Edit({ transaction, categories, accounts }) {
     // Handle amount with validation
     const handleAmountChange = (e) => {
         handleAmountInput(e, setData, 'amount');
-        const validation = validateAmount(e.target.value, false);
-        if (!validation.isValid) {
-            setFieldError('amount', validation.error);
-        } else {
-            clearFieldError('amount');
-        }
+        clearFieldError('amount');
     };
 
     // Handle date with validation
@@ -265,70 +224,12 @@ export default function Edit({ transaction, categories, accounts }) {
     const handleSubmit = (e) => {
         e.preventDefault();
 
-        const nextErrors = {};
-
-        const amountValidation = validateAmount(data.amount, false);
-        if (!amountValidation.isValid) {
-            nextErrors.amount = amountValidation.error;
-        }
-
-        const dateValidation = validateDate(data.expensed_date);
-        if (!dateValidation.isValid) {
-            nextErrors.expensed_date = dateValidation.error;
-        }
-
-        const timeValidation = validateTime(data.transaction_time);
-        if (!timeValidation.isValid) {
-            nextErrors.transaction_time = timeValidation.error;
-        }
-
-        if (!data.account_id) {
-            nextErrors.account_id = 'Account is required';
-        }
-
-        if (transactionType !== 'transfer') {
-            if (!data.payment_method) {
-                nextErrors.payment_method = 'Payment method is required';
-            }
-            if (transactionType !== 'income' && !selectedCategory) {
-                nextErrors.category = 'Category is required';
-            }
-            if (!data.category_id) {
-                nextErrors.category_id = transactionType === 'income'
-                    ? 'Income category is required'
-                    : 'Subcategory is required';
-            }
-        }
-
-        if (transactionType === 'transfer') {
-            if (!data.transfer_to_account_id) {
-                nextErrors.transfer_to_account_id = 'Destination account is required';
-            }
-            if (data.account_id && data.account_id === data.transfer_to_account_id) {
-                nextErrors.transfer = 'Source and destination accounts must be different';
-            }
-        }
-
-        if (data.description) {
-            const descValidation = validateDescription(data.description, 1000, false);
-            if (!descValidation.isValid) {
-                nextErrors.description = descValidation.error;
-            }
-        }
-
-        if (data.tags) {
-            const tagsValidation = validateTags(data.tags, 10);
-            if (!tagsValidation.isValid) {
-                nextErrors.tags = tagsValidation.error;
-            }
-        }
-
-        if (data.notes) {
-            const notesValidation = validateDescription(data.notes, 2000, false);
-            if (!notesValidation.isValid) {
-                nextErrors.notes = notesValidation.error;
-            }
-        }
+        const nextErrors = validateTransactionForm(data, {
+            transactionType,
+            selectedCategory,
+            dateField: 'expensed_date',
+            validateNotes: true,
+        });
 
         setValidationErrors(nextErrors);
 
@@ -372,20 +273,7 @@ export default function Edit({ transaction, categories, accounts }) {
                         </div>
                         <div className="card-body">
                             <form onSubmit={handleSubmit} noValidate>
-                                {errorEntries.length > 0 && (
-                                    <div className="alert alert-danger" role="alert" aria-live="polite">
-                                        <div className="fw-semibold mb-2">
-                                            Please fix the highlighted fields before saving.
-                                        </div>
-                                        <ul className="mb-0 ps-3">
-                                            {errorEntries.map(([field, message]) => (
-                                                <li key={field}>
-                                                    <strong>{errorLabels[field] || field}:</strong> {message}
-                                                </li>
-                                            ))}
-                                        </ul>
-                                    </div>
-                                )}
+                                <FormErrorSummary errorEntries={errorEntries} errorLabels={errorLabels} />
 
                                 {/* Transaction Type - Moved to top */}
                                 <div className="row mb-4">

--- a/resources/js/utils/inputValidation.js
+++ b/resources/js/utils/inputValidation.js
@@ -228,7 +228,7 @@ export const validateTags = (tags, maxTags = 10, maxTagLength = 30) => {
 /**
  * Real-time amount input handler
  */
-export const handleAmountInput = (event, setValue) => {
+export const handleAmountInput = (event, setter, fieldKey = undefined) => {
     let value = event.target.value;
 
     value = value.replace(/[^\d.-]/g, '');
@@ -246,7 +246,163 @@ export const handleAmountInput = (event, setValue) => {
         value = value.replace(/-/g, '');
     }
 
-    setValue(value);
+    if (typeof fieldKey === 'string') {
+        setter(fieldKey, value);
+    } else {
+        setter(value);
+    }
+};
+
+export const TRANSACTION_ERROR_ORDER = [
+    'transaction_date',
+    'expensed_date',
+    'transaction_time',
+    'amount',
+    'account_id',
+    'transfer_to_account_id',
+    'payment_method',
+    'category',
+    'category_id',
+    'description',
+    'payee_payer',
+    'reference_number',
+    'tax',
+    'status',
+    'tags',
+    'notes',
+    'transfer',
+];
+
+export const getTransactionErrorLabels = (transactionType = 'expense') => ({
+    transaction_date: 'Date',
+    expensed_date: 'Date',
+    transaction_time: 'Time',
+    amount: 'Amount',
+    account_id: transactionType === 'transfer' ? 'From Account' : 'Account',
+    transfer_to_account_id: 'To Account',
+    payment_method: 'Payment Method',
+    category: 'Category',
+    category_id: transactionType === 'income' ? 'Income Category' : 'Subcategory',
+    description: 'Description',
+    payee_payer: 'Payee/Payer',
+    reference_number: 'Reference Number',
+    tax: 'Tax Amount',
+    status: 'Status',
+    tags: 'Tags',
+    notes: 'Notes',
+    transfer: 'Transfer',
+});
+
+export const getErrorEntries = (validationErrors = {}, serverErrors = {}, errorOrder = TRANSACTION_ERROR_ORDER) => {
+    const combinedErrors = { ...validationErrors, ...serverErrors };
+
+    return [
+        ...errorOrder
+            .filter((field) => combinedErrors[field])
+            .map((field) => [field, combinedErrors[field]]),
+        ...Object.entries(combinedErrors)
+            .filter(([field, message]) => message && !errorOrder.includes(field)),
+    ];
+};
+
+export const setValidationFieldError = (setValidationErrors, field, message) => {
+    setValidationErrors((current) => ({ ...current, [field]: message || null }));
+};
+
+export const clearValidationFieldError = (setValidationErrors, field) => {
+    setValidationFieldError(setValidationErrors, field, null);
+};
+
+export const clearValidationFieldErrors = (setValidationErrors, fields) => {
+    setValidationErrors((current) => ({
+        ...current,
+        ...Object.fromEntries(fields.map((field) => [field, null])),
+    }));
+};
+
+export const validateTransactionForm = (data, {
+    transactionType = 'expense',
+    selectedCategory = '',
+    dateField = 'transaction_date',
+    dateAllowFuture = false,
+    includeTimeInDate = false,
+    maxPastYears = 10,
+    maxAmount = 999999999.99,
+    tagsMax = 10,
+    tagMaxLength = 30,
+    validateNotes = false,
+} = {}) => {
+    const nextErrors = {};
+
+    const amountValidation = validateAmount(data.amount, false, maxAmount);
+    if (!amountValidation.isValid) {
+        nextErrors.amount = amountValidation.error;
+    }
+
+    const dateValidation = validateDate(
+        data[dateField],
+        dateAllowFuture,
+        maxPastYears,
+        includeTimeInDate ? data.transaction_time : ''
+    );
+    if (!dateValidation.isValid) {
+        nextErrors[dateField] = dateValidation.error;
+    }
+
+    const timeValidation = validateTime(data.transaction_time);
+    if (!timeValidation.isValid) {
+        nextErrors.transaction_time = timeValidation.error;
+    }
+
+    if (!data.account_id) {
+        nextErrors.account_id = 'Account is required';
+    }
+
+    if (transactionType !== 'transfer') {
+        if (!data.payment_method) {
+            nextErrors.payment_method = 'Payment method is required';
+        }
+        if (transactionType !== 'income' && !selectedCategory) {
+            nextErrors.category = 'Category is required';
+        }
+        if (!data.category_id) {
+            nextErrors.category_id = transactionType === 'income'
+                ? 'Income category is required'
+                : 'Subcategory is required';
+        }
+    }
+
+    if (transactionType === 'transfer') {
+        if (!data.transfer_to_account_id) {
+            nextErrors.transfer_to_account_id = 'Destination account is required';
+        }
+        if (data.account_id && data.account_id === data.transfer_to_account_id) {
+            nextErrors.transfer = 'Source and destination accounts must be different';
+        }
+    }
+
+    if (data.description) {
+        const descValidation = validateDescription(data.description, 1000, false);
+        if (!descValidation.isValid) {
+            nextErrors.description = descValidation.error;
+        }
+    }
+
+    if (data.tags) {
+        const tagsValidation = validateTags(data.tags, tagsMax, tagMaxLength);
+        if (!tagsValidation.isValid) {
+            nextErrors.tags = tagsValidation.error;
+        }
+    }
+
+    if (validateNotes && data.notes) {
+        const notesValidation = validateDescription(data.notes, 2000, false);
+        if (!notesValidation.isValid) {
+            nextErrors.notes = notesValidation.error;
+        }
+    }
+
+    return nextErrors;
 };
 
 /**
@@ -277,6 +433,13 @@ export default {
     validateIFSC,
     validateTags,
     handleAmountInput,
+    TRANSACTION_ERROR_ORDER,
+    getTransactionErrorLabels,
+    getErrorEntries,
+    setValidationFieldError,
+    clearValidationFieldError,
+    clearValidationFieldErrors,
+    validateTransactionForm,
     getMaxDate,
     getMinDate
 };


### PR DESCRIPTION
## Problem

Transaction add/edit forms relied on browser-native required field behavior and did not show app-level validation feedback when required fields were missing.

Refs #20

## Changes

- Add top-level validation summaries to Add and Edit transaction forms.
- Show inline validation errors for required transaction fields.
- Collect all client-side validation errors on submit instead of stopping at the first error.
- Replace category/transfer alert flows with inline form errors.
- Fix missing alidateDescription import in the Add Transaction form.
- Keep Edit description optional to match the visible form copy and backend validation.

## Verification

- 
pm run build passed.
- composer test passed with temporary test SQLite DB/env (APP_KEY, APP_ENV=testing, DB_CONNECTION=sqlite, DB_DATABASE=/tmp/expense-manager-issue20-pr/database/database.sqlite). PHPUnit reported one warning from the baseline feature test asset lookup, but assertions passed.
- Local browser QA on http://expense.com/ was previously reviewed and accepted for #20.

## Notes

This PR is intentionally scoped to Create.jsx and Edit.jsx validation feedback only. It does not include unrelated statement import/reconciliation WIP from the local llm-integration workspace.
