### PR TITLE
[codex] Fix transaction edit time field

### DIFF
--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -283,6 +283,7 @@ class TransactionController extends Controller
     {
         // Load the transaction with its relationships
         $transaction->load(['category.parent', 'account']);
+        $transaction->transaction_time = $this->timeInputValue($transaction->transaction_time);
 
         $categories = \App\Models\Category::all();
         $accounts = \App\Models\Account::all();
@@ -292,6 +293,25 @@ class TransactionController extends Controller
             'categories' => $categories,
             'accounts' => $accounts,
         ]);
+    }
+
+    private function timeInputValue($value): ?string
+    {
+        if (! $value) {
+            return null;
+        }
+
+        $stringValue = (string) $value;
+
+        if (preg_match('/^(\\d{2}:\\d{2})(?::\\d{2})?$/', $stringValue, $matches)) {
+            return $matches[1];
+        }
+
+        if (preg_match('/(?:T|\\s)(\\d{2}:\\d{2})(?::\\d{2})?/', $stringValue, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
     }
 
     /**

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -23,6 +23,7 @@ class Transaction extends Model
         'amount',
         'description',
         'transaction_date',
+        'transaction_time',
         'payment_method',
         'reference_number',
         'tags',

--- a/database/migrations/2026_05_16_100000_add_transaction_time_to_transactions_table.php
+++ b/database/migrations/2026_05_16_100000_add_transaction_time_to_transactions_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            if (! Schema::hasColumn('transactions', 'transaction_time')) {
+                $table->time('transaction_time')->nullable()->after('transaction_date');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            if (Schema::hasColumn('transactions', 'transaction_time')) {
+                $table->dropColumn('transaction_time');
+            }
+        });
+    }
+};

--- a/resources/js/Pages/Transactions/Edit.jsx
+++ b/resources/js/Pages/Transactions/Edit.jsx
@@ -20,6 +20,15 @@ import {
     validateTransactionForm,
 } from '../../utils/inputValidation';
 
+const toTimeInputValue = (value) => {
+    if (!value) return '';
+
+    const stringValue = String(value);
+    const timeMatch = stringValue.match(/(?:T|\s)(\d{2}:\d{2})(?::\d{2})?/);
+
+    return timeMatch ? timeMatch[1] : stringValue.slice(0, 5);
+};
+
 export default function Edit({ transaction, categories, accounts }) {
     const [selectedCategory, setSelectedCategory] = useState('');
     const [subcategories, setSubcategories] = useState([]);
@@ -28,7 +37,7 @@ export default function Edit({ transaction, categories, accounts }) {
 
     const { data, setData, put, processing, errors } = useForm({
         expensed_date: transaction.transaction_date || '',
-        transaction_time: transaction.transaction_time || '',
+        transaction_time: toTimeInputValue(transaction.transaction_time),
         amount: transaction.amount || '',
         account_id: transaction.account_id || '',
         transfer_to_account_id: '',

--- a/tests/Feature/TransactionEditTest.php
+++ b/tests/Feature/TransactionEditTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\Transaction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class TransactionEditTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_edit_form_receives_transaction_time_in_time_input_format(): void
+    {
+        $account = Account::factory()->create();
+        $category = Category::factory()->create();
+
+        $transaction = Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $category->id,
+            'transaction_type' => 'expense',
+            'amount' => 125.50,
+            'description' => 'Lunch',
+            'transaction_date' => '2026-05-30',
+            'transaction_time' => '14:30:00',
+            'payment_method' => 'UPI',
+        ]);
+
+        $this->get(route('transactions.edit', $transaction))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Transactions/Edit', false)
+                ->where('transaction.id', $transaction->id)
+                ->where('transaction.transaction_time', '14:30')
+            );
+    }
+
+    public function test_edit_form_leaves_missing_transaction_time_empty(): void
+    {
+        $account = Account::factory()->create();
+        $category = Category::factory()->create();
+
+        $transaction = Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $category->id,
+            'transaction_type' => 'expense',
+            'amount' => 125.50,
+            'description' => 'Lunch',
+            'transaction_date' => '2026-05-30',
+            'transaction_time' => null,
+            'payment_method' => 'UPI',
+        ]);
+
+        $this->get(route('transactions.edit', $transaction))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Transactions/Edit', false)
+                ->where('transaction.id', $transaction->id)
+                ->where('transaction.transaction_time', null)
+            );
+    }
+}


### PR DESCRIPTION
## Summary
- Add a nullable `transaction_time` column and allow it on the Transaction model.
- Normalize edit-form transaction time props to `HH:mm` in the controller.
- Add a defensive frontend formatter for the edit time input.
- Cover populated and missing transaction time cases with a focused feature test.

Fixes #18.

## Validation
- `php artisan test tests/Feature/TransactionEditTest.php` passed.
- `npm run build` passed, with the existing large chunk warning.
- `composer test` currently fails on `Tests\Feature\ExampleTest` because the `/` smoke test hits the dashboard without migrating the `transactions` table in that test; the focused #18 test passes.