### PR TITLE
[codex] Stabilize statement import and reconciliation

### DIFF
--- a/app/Http/Controllers/StatementController.php
+++ b/app/Http/Controllers/StatementController.php
@@ -4,22 +4,39 @@ namespace App\Http\Controllers;
 
 use App\Models\Account;
 use App\Models\Category;
+use App\Models\StatementLedgerBundle;
 use App\Models\Transaction;
 use App\Services\StatementParserService;
+use App\Services\StatementReconciliationService;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class StatementController extends Controller
 {
+    private const REVIEW_SESSION_KEY = 'statement_review_snapshot';
+
     public function uploadPage(): Response
     {
         return Inertia::render('Statements/Upload');
     }
 
-    public function process(Request $request, StatementParserService $parser): Response
+    public function review(Request $request): Response|RedirectResponse
+    {
+        $snapshot = $request->session()->get(self::REVIEW_SESSION_KEY);
+        if (! is_array($snapshot)) {
+            return redirect()->route('statements.upload')
+                ->with('warning', 'Upload a statement first.');
+        }
+
+        return Inertia::render('Statements/Review', $this->reviewPagePropsFromSnapshot($snapshot));
+    }
+
+    public function process(Request $request, StatementParserService $parser, StatementReconciliationService $reconciliation): RedirectResponse
     {
         $request->validate([
             // Extension-based: many bank PDFs report as application/octet-stream and fail mimes:pdf.
@@ -46,32 +63,33 @@ class StatementController extends Controller
 
         $suggestion = $this->resolveSuggestedAccount($parsed['account_info']['account_number'] ?? null);
 
-        $accounts = Account::query()->active()->orderBy('name')->get();
-        $categories = Category::query()
-            ->active()
-            ->parent()
-            ->with(['activeChildren' => fn ($q) => $q->orderBy('name')])
-            ->orderBy('name')
-            ->get();
+        $reco = $reconciliation->analyze(
+            $parsed['transactions'],
+            $suggestion['account']?->id,
+        );
 
-        return Inertia::render('Statements/Review', [
-            'parsedData' => $parsed,
+        $parsedForReview = [
+            'account_info' => $parsed['account_info'],
+            'transactions' => $reco['transactions'],
+        ];
+
+        $snapshot = [
+            'parsedData' => $parsedForReview,
+            'reconcilePeriod' => $reco['period'],
+            'reconcileSummary' => $reco['summary'],
+            'reconcileDebug' => (bool) config('statement.reconcile_debug', false),
             'suggestedAccount' => $suggestion['account']?->only(['id', 'name', 'account_number', 'bank_name']),
             'accountMatch' => $suggestion['match'],
             'accountMatchNote' => $suggestion['note'],
-            'accounts' => $accounts->map(fn (Account $a) => $a->only(['id', 'name', 'account_number', 'bank_name']))->values()->all(),
-            'categories' => $categories->map(function (Category $c) {
-                return [
-                    'id' => $c->id,
-                    'name' => $c->name,
-                    'code' => $c->code,
-                    'active_children' => $c->activeChildren->map(fn (Category $ch) => $ch->only(['id', 'name']))->values()->all(),
-                ];
-            })->values()->all(),
-        ]);
+            'suggested_account_id' => $suggestion['account']?->id,
+        ];
+
+        $request->session()->put(self::REVIEW_SESSION_KEY, $snapshot);
+
+        return redirect()->route('statements.review');
     }
 
-    public function importTransactions(Request $request)
+    public function importTransactions(Request $request, StatementReconciliationService $reconciliation): RedirectResponse
     {
         $validated = $request->validate([
             'rows' => 'required|array|min:1',
@@ -82,38 +100,47 @@ class StatementController extends Controller
             'rows.*.account_id' => 'required|exists:accounts,id',
             'rows.*.category_id' => 'required|exists:categories,id',
             'rows.*.reference' => 'nullable|string|max:100',
+            'rows.*.review_row_index' => 'required|integer|min:0',
         ]);
+
+        $reviewRedirect = fn (): RedirectResponse => redirect()->route('statements.review');
+        $failRedirect = fn (): RedirectResponse => $request->session()->has(self::REVIEW_SESSION_KEY)
+            ? redirect()->route('statements.review')
+            : redirect()->route('statements.upload');
 
         $accountIds = collect($validated['rows'])->pluck('account_id')->unique()->all();
         $activeIds = Account::query()->active()->whereIn('id', $accountIds)->pluck('id')->all();
         if (count($activeIds) !== count($accountIds)) {
-            return back()->withErrors(['rows' => 'All accounts must be active.'])->withInput();
+            return $failRedirect()->withErrors(['rows' => 'All accounts must be active.'])->withInput();
         }
 
         $count = 0;
 
-        $incomeRootId = Category::query()->whereNull('parent_id')->where('code', 'INCOME')->value('id');
-
         foreach ($validated['rows'] as $row) {
             $category = Category::query()->with('parent')->find($row['category_id']);
             if (! $category) {
-                return back()->withErrors(['rows' => 'Invalid category for one or more rows.'])->withInput();
+                return $failRedirect()->withErrors(['rows' => 'Invalid category for one or more rows.'])->withInput();
             }
             if ($row['type'] === 'income') {
-                if (! $category->parent_id || (int) $category->parent_id !== (int) $incomeRootId) {
-                    return back()->withErrors(['rows' => 'Income transactions must use an income subcategory.'])->withInput();
+                if (! $this->categoryIsAssignableIncomeCategory($category)) {
+                    return $failRedirect()->withErrors(['rows' => 'Income transactions must use an income subcategory.'])->withInput();
                 }
             } elseif ($row['type'] === 'expense') {
                 if (! $category->parent_id) {
-                    return back()->withErrors(['rows' => 'Expense transactions must use a leaf category (subcategory).'])->withInput();
+                    return $failRedirect()->withErrors(['rows' => 'Expense transactions must use a leaf category (subcategory).'])->withInput();
                 }
-                if ($category->parent && $category->parent->code === 'INCOME') {
-                    return back()->withErrors(['rows' => 'Expense transactions cannot use an income category.'])->withInput();
+                if ($this->categoryTreeRootIsIncome($category)) {
+                    return $failRedirect()->withErrors(['rows' => 'Expense transactions cannot use an income category.'])->withInput();
                 }
             }
         }
 
-        DB::transaction(function () use ($validated, &$count) {
+        $importDuplicateMessages = $this->validateImportDuplicates($validated['rows']);
+        if ($importDuplicateMessages !== []) {
+            return $failRedirect()->withErrors($importDuplicateMessages)->withInput();
+        }
+
+        DB::transaction(function () use ($validated, &$count): void {
             foreach ($validated['rows'] as $row) {
                 Transaction::create([
                     'account_id' => $row['account_id'],
@@ -129,8 +156,189 @@ class StatementController extends Controller
             }
         });
 
+        $snapshot = $request->session()->get(self::REVIEW_SESSION_KEY);
+        if (is_array($snapshot) && isset($snapshot['parsedData']['transactions']) && is_array($snapshot['parsedData']['transactions'])) {
+            $indicesToRemove = collect($validated['rows'])
+                ->pluck('review_row_index')
+                ->map(fn ($v) => (int) $v)
+                ->unique()
+                ->sortDesc()
+                ->values()
+                ->all();
+
+            $txns = $snapshot['parsedData']['transactions'];
+            foreach ($indicesToRemove as $idx) {
+                unset($txns[$idx]);
+            }
+            $txns = array_values($txns);
+
+            if ($txns === []) {
+                $request->session()->forget(self::REVIEW_SESSION_KEY);
+
+                return redirect()->route('statements.upload')
+                    ->with('success', "{$count} transaction(s) imported. All statement rows are processed.");
+            }
+
+            $reco = $reconciliation->analyze($txns, $snapshot['suggested_account_id'] ?? null);
+            $snapshot['parsedData']['transactions'] = $reco['transactions'];
+            $snapshot['reconcilePeriod'] = $reco['period'];
+            $snapshot['reconcileSummary'] = $reco['summary'];
+            $request->session()->put(self::REVIEW_SESSION_KEY, $snapshot);
+
+            return $reviewRedirect()->with('success', "{$count} transaction(s) imported. Continue reviewing remaining rows.");
+        }
+
         return redirect()->route('transactions.index')
             ->with('success', "{$count} transactions imported successfully!");
+    }
+
+    public function bundleLink(Request $request, StatementReconciliationService $reconciliation): RedirectResponse
+    {
+        $validated = $request->validate([
+            'account_id' => 'required|exists:accounts,id',
+            'ledger_transaction_id' => 'required|exists:transactions,id',
+            'rows' => 'required|array|min:2',
+            'rows.*.statement_sequence' => 'nullable|integer',
+            'rows.*.date' => 'required|date',
+            'rows.*.amount' => 'required|numeric|min:0.01',
+            'rows.*.type' => 'required|in:income,expense',
+            'rows.*.description' => 'nullable|string|max:65535',
+        ]);
+
+        $failRedirect = $request->session()->has(self::REVIEW_SESSION_KEY)
+            ? redirect()->route('statements.review')
+            : redirect()->route('statements.upload');
+
+        $account = Account::query()->active()->find((int) $validated['account_id']);
+        if ($account === null) {
+            return $failRedirect->withErrors(['account_id' => 'Account must be active.'])->withInput();
+        }
+
+        $ledger = Transaction::query()->findOrFail((int) $validated['ledger_transaction_id']);
+        if ((int) $ledger->account_id !== (int) $validated['account_id']) {
+            return $failRedirect->withErrors(['ledger_transaction_id' => 'That transaction belongs to a different account.'])->withInput();
+        }
+
+        foreach ($validated['rows'] as $row) {
+            if ($row['type'] !== $ledger->transaction_type) {
+                return $failRedirect->withErrors(['rows' => 'Each selected row must have the same type as the ledger transaction (income vs expense).'])->withInput();
+            }
+        }
+
+        $sumRows = round(collect($validated['rows'])->sum(fn ($r) => (float) $r['amount']), 2);
+        if (abs($sumRows - (float) $ledger->amount) > 0.02) {
+            return $failRedirect->withErrors([
+                'rows' => 'The sum of selected statement amounts ('.$sumRows.') must equal the ledger amount ('.$ledger->amount.').',
+            ])->withInput();
+        }
+
+        DB::transaction(function () use ($validated): void {
+            $bundle = StatementLedgerBundle::create([
+                'account_id' => (int) $validated['account_id'],
+                'ledger_transaction_id' => (int) $validated['ledger_transaction_id'],
+            ]);
+
+            foreach ($validated['rows'] as $row) {
+                $bundle->rows()->create([
+                    'statement_sequence' => $row['statement_sequence'] ?? null,
+                    'statement_date' => $row['date'],
+                    'amount' => $row['amount'],
+                    'description' => $row['description'] ?? null,
+                ]);
+            }
+        });
+
+        $snapshot = $request->session()->get(self::REVIEW_SESSION_KEY);
+        if (is_array($snapshot) && isset($snapshot['parsedData']['transactions']) && is_array($snapshot['parsedData']['transactions'])) {
+            $reco = $reconciliation->analyze($snapshot['parsedData']['transactions'], $snapshot['suggested_account_id'] ?? null);
+            $snapshot['parsedData']['transactions'] = $reco['transactions'];
+            $snapshot['reconcilePeriod'] = $reco['period'];
+            $snapshot['reconcileSummary'] = $reco['summary'];
+            $request->session()->put(self::REVIEW_SESSION_KEY, $snapshot);
+
+            return redirect()->route('statements.review')
+                ->with('success', 'Split rows linked to the ledger transaction and reconciliation refreshed.');
+        }
+
+        return redirect()->route('statements.upload')
+            ->with('success', 'Split statement rows linked to the ledger transaction. Upload the same statement again to see bundle matches.');
+    }
+
+    public function enrichTransactions(Request $request, StatementReconciliationService $reconciliation): RedirectResponse
+    {
+        $validated = $request->validate([
+            'updates' => 'required|array|min:1',
+            'updates.*.transaction_id' => 'required|exists:transactions,id',
+            'updates.*.description' => 'required|string|max:65535',
+            'updates.*.reference' => 'nullable|string|max:100',
+            'updates.*.transaction_date' => 'nullable|date',
+        ]);
+
+        DB::transaction(function () use ($validated): void {
+            foreach ($validated['updates'] as $u) {
+                $txn = Transaction::query()->findOrFail((int) $u['transaction_id']);
+                $reference = array_key_exists('reference', $u) ? $u['reference'] : $txn->reference_number;
+                $payload = [
+                    'description' => $u['description'],
+                    'reference_number' => $reference,
+                ];
+                if (array_key_exists('transaction_date', $u) && $u['transaction_date'] !== null && $u['transaction_date'] !== '') {
+                    $payload['transaction_date'] = $u['transaction_date'];
+                }
+                $txn->update($payload);
+            }
+        });
+
+        $n = count($validated['updates']);
+
+        $snapshot = $request->session()->get(self::REVIEW_SESSION_KEY);
+        if (is_array($snapshot) && isset($snapshot['parsedData']['transactions']) && is_array($snapshot['parsedData']['transactions'])) {
+            $reco = $reconciliation->analyze($snapshot['parsedData']['transactions'], $snapshot['suggested_account_id'] ?? null);
+            $snapshot['parsedData']['transactions'] = $reco['transactions'];
+            $snapshot['reconcilePeriod'] = $reco['period'];
+            $snapshot['reconcileSummary'] = $reco['summary'];
+            $request->session()->put(self::REVIEW_SESSION_KEY, $snapshot);
+
+            return redirect()->route('statements.review')
+                ->with('success', "{$n} transaction(s) updated and checked against the ledger.");
+        }
+
+        return redirect()->route('statements.upload')
+            ->with('success', "{$n} transaction(s) updated from statement.");
+    }
+
+    /**
+     * @param  array<string, mixed>  $snapshot
+     * @return array<string, mixed>
+     */
+    private function reviewPagePropsFromSnapshot(array $snapshot): array
+    {
+        $accounts = Account::query()->active()->orderBy('name')->get();
+        $categories = Category::query()
+            ->active()
+            ->parent()
+            ->with(['activeChildren' => fn ($q) => $q->orderBy('name')])
+            ->orderBy('name')
+            ->get();
+
+        return [
+            'parsedData' => $snapshot['parsedData'],
+            'reconcilePeriod' => $snapshot['reconcilePeriod'],
+            'reconcileSummary' => $snapshot['reconcileSummary'],
+            'reconcileDebug' => $snapshot['reconcileDebug'] ?? false,
+            'suggestedAccount' => $snapshot['suggestedAccount'],
+            'accountMatch' => $snapshot['accountMatch'],
+            'accountMatchNote' => $snapshot['accountMatchNote'],
+            'accounts' => $accounts->map(fn (Account $a) => $a->only(['id', 'name', 'account_number', 'bank_name']))->values()->all(),
+            'categories' => $categories->map(function (Category $c) {
+                return [
+                    'id' => $c->id,
+                    'name' => $c->name,
+                    'code' => $c->code,
+                    'active_children' => $c->activeChildren->map(fn (Category $ch) => $ch->only(['id', 'name']))->values()->all(),
+                ];
+            })->values()->all(),
+        ];
     }
 
     /**
@@ -201,5 +409,138 @@ class StatementController extends Controller
         $digits = preg_replace('/\D+/', '', $value);
 
         return $digits ?? '';
+    }
+
+    /**
+     * Detect duplicate lines in the import batch and duplicates of existing ledger rows (same account,
+     * date, type, amount, reference, and whitespace-normalized lowercase description).
+     *
+     * @param  array<int, array<string, mixed>>  $rows
+     * @return array<string, string>
+     */
+    private function validateImportDuplicates(array $rows): array
+    {
+        $errors = [];
+        $duplicateInBatchMessage = 'Duplicate in this import: same account, date, type, amount, reference, and normalized description.';
+        $duplicateInLedgerMessage = 'Already in ledger: matching account, date, type, amount, reference, and description.';
+
+        $buckets = [];
+        foreach ($rows as $idx => $row) {
+            $buckets[$this->importDedupFingerprint($row)][] = (int) $idx;
+        }
+        foreach ($buckets as $indices) {
+            if (count($indices) < 2) {
+                continue;
+            }
+            foreach ($indices as $i) {
+                $errors["rows.{$i}.description"] = $duplicateInBatchMessage;
+                $errors["rows.{$i}.amount"] = $duplicateInBatchMessage;
+            }
+        }
+
+        foreach ($rows as $idx => $row) {
+            if (isset($errors["rows.{$idx}.description"])) {
+                continue;
+            }
+            if (! $this->importRowMatchesExistingTransaction($row)) {
+                continue;
+            }
+            $errors["rows.{$idx}.description"] = $duplicateInLedgerMessage;
+            $errors["rows.{$idx}.amount"] = $duplicateInLedgerMessage;
+        }
+
+        return $errors;
+    }
+
+    /** @param  array<string, mixed>  $row */
+    private function normalizedImportDescription(mixed $description): string
+    {
+        if (! is_string($description)) {
+            return '';
+        }
+
+        return Str::squish(Str::lower($description));
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function normalizedImportReference(mixed $reference): string
+    {
+        if ($reference === null) {
+            return '';
+        }
+
+        return Str::squish(Str::lower((string) $reference));
+    }
+
+    /** @param  array<string, mixed>  $row */
+    private function importDedupFingerprint(array $row): string
+    {
+        return implode("\n", [
+            (string) $row['account_id'],
+            (string) $row['date'],
+            (string) $row['type'],
+            sprintf('%.2f', round((float) $row['amount'], 2)),
+            $this->normalizedImportReference($row['reference'] ?? null),
+            $this->normalizedImportDescription($row['description']),
+        ]);
+    }
+
+    /** @param  array<string, mixed>  $row */
+    private function importRowMatchesExistingTransaction(array $row): bool
+    {
+        $targetDesc = $this->normalizedImportDescription($row['description']);
+        $targetRef = $this->normalizedImportReference($row['reference'] ?? null);
+        $targetAmount = sprintf('%.2f', round((float) $row['amount'], 2));
+
+        $candidates = Transaction::query()
+            ->where('account_id', (int) $row['account_id'])
+            ->whereDate('transaction_date', $row['date'])
+            ->where('transaction_type', $row['type'])
+            ->get(['description', 'amount', 'reference_number']);
+
+        foreach ($candidates as $txn) {
+            $amount = sprintf('%.2f', round((float) $txn->amount, 2));
+            if ($amount !== $targetAmount) {
+                continue;
+            }
+            if ($this->normalizedImportReference($txn->reference_number) !== $targetRef) {
+                continue;
+            }
+            if ($this->normalizedImportDescription((string) ($txn->description ?? '')) !== $targetDesc) {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private function categoryTreeRoot(Category $category): Category
+    {
+        $current = $category;
+        for ($i = 0; $i < 64 && $current->parent_id !== null; $i++) {
+            $current->loadMissing('parent');
+            $current = $current->parent;
+        }
+
+        return $current;
+    }
+
+    private function categoryTreeRootIsIncome(Category $category): bool
+    {
+        return strtoupper((string) ($this->categoryTreeRoot($category)->code ?? '')) === 'INCOME';
+    }
+
+    /** True when category is a child/descendant under the Income tree (not the bare Income root row). */
+    private function categoryIsAssignableIncomeCategory(Category $category): bool
+    {
+        if ($category->parent_id === null) {
+            return false;
+        }
+
+        return $this->categoryTreeRootIsIncome($category);
     }
 }

--- a/app/Models/StatementLedgerBundle.php
+++ b/app/Models/StatementLedgerBundle.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class StatementLedgerBundle extends Model
+{
+    protected $fillable = [
+        'account_id',
+        'ledger_transaction_id',
+    ];
+
+    public function account(): BelongsTo
+    {
+        return $this->belongsTo(Account::class);
+    }
+
+    public function ledgerTransaction(): BelongsTo
+    {
+        return $this->belongsTo(Transaction::class, 'ledger_transaction_id');
+    }
+
+    /** @return HasMany<StatementLedgerBundleRow, $this> */
+    public function rows(): HasMany
+    {
+        return $this->hasMany(StatementLedgerBundleRow::class, 'bundle_id');
+    }
+}

--- a/app/Models/StatementLedgerBundleRow.php
+++ b/app/Models/StatementLedgerBundleRow.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class StatementLedgerBundleRow extends Model
+{
+    protected $fillable = [
+        'bundle_id',
+        'statement_sequence',
+        'statement_date',
+        'amount',
+        'description',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'statement_date' => 'date',
+            'amount' => 'decimal:2',
+        ];
+    }
+
+    public function bundle(): BelongsTo
+    {
+        return $this->belongsTo(StatementLedgerBundle::class, 'bundle_id');
+    }
+}

--- a/app/Services/StatementMatchKeyService.php
+++ b/app/Services/StatementMatchKeyService.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Transaction;
+use Carbon\CarbonInterface;
+
+/**
+ * Builds deterministic statement-vs-ledger fingerprints from date, amount, and normalized description.
+ */
+class StatementMatchKeyService
+{
+    public function normalizeDescription(string $description): string
+    {
+        $desc = strtolower($description);
+        if (preg_match('/upi\/\d+/i', $desc, $m)) {
+            return strtolower($m[0]);
+        }
+
+        return substr((string) preg_replace('/[^a-z0-9]/', '', $desc), 0, 30);
+    }
+
+    /**
+     * @param  float|string  $amount  Positive magnitude (debit or credit from statement).
+     */
+    public function formatAmountForKey(float|string $amount): string
+    {
+        return sprintf('%.2f', round((float) $amount, 2));
+    }
+
+    /**
+     * @param  float|string  $amount  Positive magnitude matching imported transactions.amount.
+     */
+    public function matchKey(string $dateYmd, float|string $amount, string $description): string
+    {
+        return $dateYmd.'_'.$this->formatAmountForKey($amount).'_'.$this->normalizeDescription($description);
+    }
+
+    /**
+     * Secondary reconcile fingerprint (amount + normalized description, no calendar date).
+     */
+    public function matchKeyAmountNormDesc(float|string $amount, string $description): string
+    {
+        return $this->formatAmountForKey($amount).'_'.$this->normalizeDescription($description);
+    }
+
+    /**
+     * Thin-only bucket without date (pair thin ledger rows when statement date differs).
+     */
+    public function thinAmountOnlyBucketKey(float|string $amount): string
+    {
+        return $this->formatAmountForKey($amount).'_thin_bucket';
+    }
+
+    /**
+     * DB Transaction → same key shape as parsed statement rows.
+     */
+    public function matchKeyFromDbTransaction(Transaction $transaction): string
+    {
+        $date = $transaction->transaction_date instanceof CarbonInterface
+            ? $transaction->transaction_date->format('Y-m-d')
+            : (string) $transaction->transaction_date;
+
+        return $this->matchKey($date, (float) $transaction->amount, (string) ($transaction->description ?? ''));
+    }
+
+    public function isDescriptionThin(?string $description): bool
+    {
+        $t = trim((string) $description);
+        if ($t === '') {
+            return true;
+        }
+        if (strlen($t) < 4) {
+            return true;
+        }
+        if (stripos($t, 'Synced from external DB') !== false) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/app/Services/StatementParserService.php
+++ b/app/Services/StatementParserService.php
@@ -37,8 +37,7 @@ class StatementParserService
         $raw = (string) file_get_contents($path);
         $split = $this->splitter->splitCsvContent($raw);
 
-        $accountInfo = $this->extractAccountInfoWithLlm($split['preamble']);
-        $accountInfo = $this->enrichAccountInfoFromPreambleKeyValues($split['preamble'], $accountInfo);
+        $accountInfo = $this->extractAccountInfoFromPreamble($split['preamble']);
         $transactions = $split['table_csv'] !== null
             ? $this->parseTransactionsFromTableCsv($split['table_csv'])
             : [];
@@ -54,8 +53,7 @@ class StatementParserService
         $text = $this->extractFromPdf($file);
         $split = $this->splitter->splitPdfText($text);
 
-        $accountInfo = $this->extractAccountInfoWithLlm($split['preamble']);
-        $accountInfo = $this->enrichAccountInfoFromPreambleKeyValues($split['preamble'], $accountInfo);
+        $accountInfo = $this->extractAccountInfoFromPreamble($split['preamble']);
         $transactions = $this->parseTransactionsFromTableCsv($split['body']);
 
         return $this->mergeResult($accountInfo, $transactions);
@@ -67,6 +65,23 @@ class StatementParserService
         $pdf = $parser->parseFile($file->getRealPath() ?: $file->getPathname());
 
         return $pdf->getText() ?: '';
+    }
+
+    /**
+     * Prefer deterministic statement header key-values over LLM calls.
+     *
+     * @return array<string, mixed>
+     */
+    private function extractAccountInfoFromPreamble(string $preamble): array
+    {
+        $fromFile = $this->parseKeyValuePreambleLines($preamble);
+        if ($this->hasUsefulPreambleAccountInfo($fromFile)) {
+            return array_merge($this->emptyAccountInfo(), $fromFile);
+        }
+
+        $accountInfo = $this->extractAccountInfoWithLlm($preamble);
+
+        return $this->enrichAccountInfoFromPreambleKeyValues($preamble, $accountInfo);
     }
 
     /**
@@ -200,6 +215,19 @@ class StatementParserService
         return $out;
     }
 
+    /** @param  array<string, string|null>  $accountInfo */
+    private function hasUsefulPreambleAccountInfo(array $accountInfo): bool
+    {
+        foreach (['account_number', 'ifsc_code', 'account_holder_name'] as $key) {
+            $value = $accountInfo[$key] ?? null;
+            if (is_string($value) && trim($value) !== '') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private function buildPreambleAccountPrompt(string $preamble): string
     {
         return <<<PROMPT
@@ -326,7 +354,7 @@ PROMPT;
             return null;
         }
 
-        array_pop($parts); // balance (not used for classification)
+        $balanceRaw = (string) array_pop($parts);
         $creditRaw = (string) array_pop($parts);
         $debitRaw = (string) array_pop($parts);
 
@@ -370,12 +398,26 @@ PROMPT;
 
         $ref = $reference !== '' ? $reference : null;
 
+        $balanceParsed = $this->parseAmount($balanceRaw);
+        $statementSequence = null;
+        if ($reference !== '' && ctype_digit($reference)) {
+            $statementSequence = (int) $reference;
+        }
+
+        $debitAmt = ($debit !== null && $debit > 0) ? round($debit, 2) : 0.0;
+        $creditAmt = ($credit !== null && $credit > 0) ? round($credit, 2) : 0.0;
+
         return [
             'date' => $date,
             'description' => $description,
             'amount' => round($amount, 2),
             'type' => $incomeExpense,
             'reference' => $ref,
+            'balance_after' => $balanceParsed !== null ? round($balanceParsed, 2) : null,
+            'balance_raw' => $balanceRaw !== '' ? $balanceRaw : null,
+            'statement_sequence' => $statementSequence,
+            'debit_amount' => $debitAmt,
+            'credit_amount' => $creditAmt,
         ];
     }
 
@@ -401,7 +443,7 @@ PROMPT;
 
     /**
      * @param  array<string, string>  $norm
-     * @return array{date: string, description: string, amount: float, type: string, reference: string|null}|null
+     * @return array<string, mixed>|null
      */
     private function mapRowToTransaction(array $norm): ?array
     {
@@ -440,13 +482,31 @@ PROMPT;
 
         $reference = $norm['srno'] ?? $norm['sno'] ?? $norm['serialno'] ?? $norm['ref'] ?? $norm['referenceno'] ?? null;
 
-        return [
+        $balanceRaw = $norm['balance'] ?? $norm['closingbalance'] ?? $norm['availablebalance'] ?? $norm['bal'] ?? null;
+        $balanceParsed = $balanceRaw !== null && $balanceRaw !== '' ? $this->parseAmount($balanceRaw) : null;
+
+        $statementSequence = null;
+        if ($reference !== null && $reference !== '' && ctype_digit($reference)) {
+            $statementSequence = (int) $reference;
+        }
+
+        $debitAmt = ($debit !== null && $debit > 0) ? round($debit, 2) : 0.0;
+        $creditAmt = ($credit !== null && $credit > 0) ? round($credit, 2) : 0.0;
+
+        $row = [
             'date' => $date,
             'description' => $description,
             'amount' => round($amount, 2),
             'type' => $type,
             'reference' => $reference !== null && $reference !== '' ? $reference : null,
+            'balance_after' => $balanceParsed !== null ? round($balanceParsed, 2) : null,
+            'balance_raw' => ($balanceRaw !== null && $balanceRaw !== '') ? $balanceRaw : null,
+            'statement_sequence' => $statementSequence,
+            'debit_amount' => $debitAmt,
+            'credit_amount' => $creditAmt,
         ];
+
+        return $row;
     }
 
     private function parseAmount(?string $raw): ?float
@@ -474,8 +534,29 @@ PROMPT;
     {
         return [
             'account_info' => array_merge($this->emptyAccountInfo(), $accountInfo),
-            'transactions' => $transactions,
+            'transactions' => $this->sortTransactionsForStatementOrder($transactions),
         ];
+    }
+
+    /**
+     * Stable statement order: Sr.No. when present, then ISO date.
+     *
+     * @param  array<int, array<string, mixed>>  $transactions
+     * @return array<int, array<string, mixed>>
+     */
+    private function sortTransactionsForStatementOrder(array $transactions): array
+    {
+        usort($transactions, function (array $a, array $b): int {
+            $seqA = $a['statement_sequence'] ?? PHP_INT_MAX;
+            $seqB = $b['statement_sequence'] ?? PHP_INT_MAX;
+            if ($seqA !== $seqB) {
+                return $seqA <=> $seqB;
+            }
+
+            return strcmp((string) ($a['date'] ?? ''), (string) ($b['date'] ?? ''));
+        });
+
+        return array_values($transactions);
     }
 
     /**

--- a/app/Services/StatementReconciliationService.php
+++ b/app/Services/StatementReconciliationService.php
@@ -1,0 +1,855 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\StatementLedgerBundle;
+use App\Models\Transaction;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class StatementReconciliationService
+{
+    private const CHAIN_EPSILON = 0.02;
+
+    public function __construct(
+        private StatementMatchKeyService $matchKeys,
+    ) {}
+
+    /**
+     * @param  array<int, array<string, mixed>>  $parsedTransactions  Rows from StatementParserService::parse
+     * @return array{
+     *     period: array{start: string|null, end: string|null},
+     *     summary: array<string, mixed>,
+     *     transactions: array<int, array<string, mixed>>
+     * }
+     */
+    public function analyze(array $parsedTransactions, ?int $accountId): array
+    {
+        $period = $this->derivePeriod($parsedTransactions);
+        $skewDays = max(0, (int) config('statement.reconcile_date_skew_days', 3));
+        $thinProximityMaxDays = config('statement.reconcile_thin_proximity_max_days');
+        $thinProximityMaxDays = $thinProximityMaxDays !== null ? max(0, (int) $thinProximityMaxDays) : null;
+        $debugReconcile = (bool) config('statement.reconcile_debug', false);
+
+        $expandedStart = null;
+        $expandedEnd = null;
+        if ($period['start'] && $period['end']) {
+            $expandedStart = Carbon::parse($period['start'])->subDays($skewDays)->format('Y-m-d');
+            $expandedEnd = Carbon::parse($period['end'])->addDays($skewDays)->format('Y-m-d');
+        }
+
+        $balanceSummary = $this->computeBalanceSummary(
+            $parsedTransactions,
+            $accountId,
+            $expandedStart,
+            $expandedEnd,
+        );
+
+        if ($accountId === null || $parsedTransactions === []) {
+            return [
+                'period' => $period,
+                'summary' => [
+                    'period_start' => $period['start'],
+                    'period_end' => $period['end'],
+                    'missing_in_db' => 0,
+                    'matched_complete' => 0,
+                    'matched_needs_enrichment' => 0,
+                    'balance' => $balanceSummary,
+                ],
+                'transactions' => $this->annotateUnscoped($parsedTransactions),
+            ];
+        }
+
+        $dbExpanded = Transaction::query()
+            ->where('account_id', $accountId)
+            ->with(['category.parent'])
+            ->when($expandedStart && $expandedEnd, function ($q) use ($expandedStart, $expandedEnd): void {
+                $q->whereDate('transaction_date', '>=', $expandedStart)
+                    ->whereDate('transaction_date', '<=', $expandedEnd);
+            })
+            ->orderBy('transaction_date')
+            ->orderBy('id')
+            ->get();
+
+        /** @var array<string, Transaction> $firstByKey */
+        $firstByKey = [];
+        /** @var array<string, array<int, Transaction>> $thinBucketsMulti */
+        $thinBucketsMulti = [];
+        /** @var array<string, array<int, Transaction>> $secondaryBuckets */
+        $secondaryBuckets = [];
+        /** @var array<string, array<int, Transaction>> $thinAmountBuckets */
+        $thinAmountBuckets = [];
+
+        foreach ($dbExpanded as $txn) {
+            $fk = $this->matchKeys->matchKeyFromDbTransaction($txn);
+            if (! isset($firstByKey[$fk])) {
+                $firstByKey[$fk] = $txn;
+            }
+
+            $descDb = (string) ($txn->description ?? '');
+            $amt = (float) $txn->amount;
+            $secKey = $this->matchKeys->matchKeyAmountNormDesc($amt, $descDb);
+            $secondaryBuckets[$secKey][] = $txn;
+
+            $dateDb = $txn->transaction_date instanceof Carbon
+                ? $txn->transaction_date->format('Y-m-d')
+                : Carbon::parse((string) $txn->transaction_date)->format('Y-m-d');
+
+            if ($this->matchKeys->isDescriptionThin($descDb)) {
+                $bk = $this->thinDbBucketKey($dateDb, $amt);
+                $thinBucketsMulti[$bk][] = $txn;
+                $amtKey = $this->matchKeys->thinAmountOnlyBucketKey($amt);
+                $thinAmountBuckets[$amtKey][] = $txn;
+            }
+        }
+
+        $statementNet = $this->statementNetDelta($parsedTransactions);
+        $narrowDb = $this->narrowDbTransactions($dbExpanded, $period);
+        $dbNet = $this->dbNetDelta($narrowDb);
+        $balanceSummary['net_delta_statement_minus_db'] = round($statementNet - $dbNet, 2);
+
+        /** @var array<int, true> $usedLedgerIds */
+        $usedLedgerIds = [];
+
+        $bundleAssignments = $this->resolveBundleAssignments($parsedTransactions, $accountId);
+        foreach ($bundleAssignments as $assignment) {
+            $usedLedgerIds[$assignment['txn']->id] = true;
+        }
+
+        $counts = ['missing_in_db' => 0, 'matched_complete' => 0, 'matched_needs_enrichment' => 0];
+
+        $n = count($parsedTransactions);
+        /** @var array<int, Transaction|null> $matches */
+        $matches = array_fill(0, $n, null);
+        /** @var array<int, array<string, mixed>> */
+        $matchMeta = array_fill(0, $n, [
+            'matched_via_thin_bucket' => false,
+            'matched_via_thin_amount' => false,
+            'matched_via_bundle' => false,
+            'bundle_id' => null,
+            'miss_reason' => null,
+        ]);
+
+        foreach ($bundleAssignments as $idx => $assignment) {
+            $matches[(int) $idx] = $assignment['txn'];
+            $matchMeta[(int) $idx]['matched_via_bundle'] = true;
+            $matchMeta[(int) $idx]['bundle_id'] = $assignment['bundle_id'];
+            $matchMeta[(int) $idx]['miss_reason'] = 'matched_bundle';
+        }
+
+        $sortedIndices = $this->sortedStatementIndices($parsedTransactions);
+
+        foreach ($sortedIndices as $idx) {
+            if ($matches[$idx] !== null) {
+                continue;
+            }
+
+            $row = $parsedTransactions[$idx];
+            $desc = (string) ($row['description'] ?? '');
+            $date = (string) ($row['date'] ?? '');
+            $amount = (float) ($row['amount'] ?? 0);
+            $stmtType = (string) ($row['type'] ?? '');
+            $keyStmt = $this->matchKeys->matchKey($date, $amount, $desc);
+
+            $match = null;
+            $thinBucket = false;
+            $thinAmount = false;
+            $missReason = 'none';
+
+            $primaryCand = $firstByKey[$keyStmt] ?? null;
+            if ($primaryCand !== null && ! isset($usedLedgerIds[$primaryCand->id])) {
+                $match = $primaryCand;
+                $missReason = 'matched_primary';
+            }
+
+            if ($match === null) {
+                $bk = $this->thinDbBucketKey($date, $amount);
+                $list = $thinBucketsMulti[$bk] ?? [];
+                $picked = $this->pickNearestUnusedThin($list, $date, $stmtType, $usedLedgerIds, $thinProximityMaxDays);
+                if ($picked !== null) {
+                    $match = $picked;
+                    $thinBucket = true;
+                    $missReason = 'matched_thin_date_bucket';
+                }
+            }
+
+            if ($match === null) {
+                $secStmtKey = $this->matchKeys->matchKeyAmountNormDesc($amount, $desc);
+                $secList = $secondaryBuckets[$secStmtKey] ?? [];
+                if (count($secList) === 1) {
+                    if (! isset($usedLedgerIds[$secList[0]->id])) {
+                        $match = $secList[0];
+                        $missReason = 'matched_secondary_unique';
+                    } else {
+                        $missReason = 'secondary_candidate_already_used';
+                    }
+                } elseif (count($secList) > 1) {
+                    $missReason = 'secondary_ambiguous';
+                } else {
+                    $missReason = 'secondary_miss';
+                }
+            }
+
+            if ($match === null) {
+                $atk = $this->matchKeys->thinAmountOnlyBucketKey($amount);
+                $amtList = $thinAmountBuckets[$atk] ?? [];
+                $picked = $this->pickNearestUnusedThin($amtList, $date, $stmtType, $usedLedgerIds, $thinProximityMaxDays);
+                if ($picked !== null) {
+                    $match = $picked;
+                    $thinAmount = true;
+                    $missReason = 'matched_thin_amount_proximity';
+                } elseif ($amtList !== []) {
+                    $missReason = 'thin_amount_filtered_or_used';
+                }
+            }
+
+            if ($match === null) {
+                $matchMeta[$idx]['miss_reason'] = $missReason === 'none' ? 'no_candidates' : $missReason;
+
+                continue;
+            }
+
+            $matchMeta[$idx]['matched_via_thin_bucket'] = $thinBucket;
+            $matchMeta[$idx]['matched_via_thin_amount'] = $thinAmount;
+            $matchMeta[$idx]['miss_reason'] = $missReason;
+            $matches[$idx] = $match;
+            $usedLedgerIds[$match->id] = true;
+        }
+
+        $out = [];
+        for ($idx = 0; $idx < $n; $idx++) {
+            $row = $parsedTransactions[$idx];
+            $desc = (string) ($row['description'] ?? '');
+            $date = (string) ($row['date'] ?? '');
+            $amount = (float) ($row['amount'] ?? 0);
+            $keyStmt = $this->matchKeys->matchKey($date, $amount, $desc);
+
+            $match = $matches[$idx];
+            $meta = $matchMeta[$idx];
+
+            $matchedViaThinBucket = $meta['matched_via_thin_bucket'];
+            $matchedViaThinAmountOnly = $meta['matched_via_thin_amount'];
+            $matchedViaBundle = $meta['matched_via_bundle'];
+
+            $ledgerTransactionDate = null;
+            if ($match !== null) {
+                $ledgerTransactionDate = $match->transaction_date instanceof Carbon
+                    ? $match->transaction_date->format('Y-m-d')
+                    : Carbon::parse((string) $match->transaction_date)->format('Y-m-d');
+            }
+
+            $dateDrift = $match !== null && $date !== '' && $ledgerTransactionDate !== null && $ledgerTransactionDate !== $date;
+
+            $status = 'missing_in_db';
+            $existingId = null;
+            $displayDescription = $desc;
+            $needsDetailReasons = [];
+
+            if ($match !== null) {
+                $existingId = $match->id;
+                $thinDb = $this->matchKeys->isDescriptionThin((string) ($match->description ?? ''));
+                $needsDetailReasons = $this->needsDetailReasons(
+                    $thinDb,
+                    $matchedViaThinBucket,
+                    $matchedViaThinAmountOnly,
+                    $dateDrift,
+                    $matchedViaBundle,
+                );
+                $needsDetail = $needsDetailReasons !== [];
+
+                if ($needsDetail && trim($desc) !== '') {
+                    $status = 'matched_needs_enrichment';
+                    $displayDescription = $desc;
+                    $counts['matched_needs_enrichment']++;
+                    $this->logNeedsDetailRow(
+                        $idx,
+                        $row,
+                        $accountId,
+                        $date,
+                        $ledgerTransactionDate,
+                        $amount,
+                        $existingId,
+                        $needsDetailReasons,
+                        (string) ($meta['miss_reason'] ?? 'unknown'),
+                        $desc,
+                        (string) ($match->description ?? ''),
+                    );
+                } elseif (! $needsDetail) {
+                    $status = 'matched_complete';
+                    $counts['matched_complete']++;
+                } else {
+                    $status = 'matched_complete';
+                    $counts['matched_complete']++;
+                }
+            } else {
+                $counts['missing_in_db']++;
+            }
+
+            $hints = $this->ledgerCategoryHints($match);
+
+            $merged = array_merge($row, [
+                'reconcile_status' => $status,
+                'existing_transaction_id' => $existingId,
+                'match_key' => $keyStmt,
+                'display_description' => $displayDescription,
+                'db_description_snapshot' => $match ? (string) ($match->description ?? '') : null,
+                'db_reference_snapshot' => $match ? (string) ($match->reference_number ?? '') : null,
+                'ledger_category_id' => $hints['ledger_category_id'],
+                'ledger_subcategory_id' => $hints['ledger_subcategory_id'],
+                'date_drift' => $dateDrift,
+                'ledger_transaction_date' => $ledgerTransactionDate,
+                'matched_via_bundle' => $matchedViaBundle,
+                'bundle_id' => $meta['bundle_id'],
+                'needs_detail_reasons' => $needsDetailReasons,
+            ]);
+
+            if ($debugReconcile) {
+                $merged['match_attempt_reason'] = $match !== null
+                    ? (string) ($meta['miss_reason'] ?? 'unknown')
+                    : (string) ($meta['miss_reason'] ?? 'miss_unknown');
+            }
+
+            $out[] = $merged;
+        }
+
+        return [
+            'period' => $period,
+            'summary' => [
+                'period_start' => $period['start'],
+                'period_end' => $period['end'],
+                'missing_in_db' => $counts['missing_in_db'],
+                'matched_complete' => $counts['matched_complete'],
+                'matched_needs_enrichment' => $counts['matched_needs_enrichment'],
+                'balance' => $balanceSummary,
+            ],
+            'transactions' => $out,
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function needsDetailReasons(
+        bool $thinDb,
+        bool $matchedViaThinBucket,
+        bool $matchedViaThinAmountOnly,
+        bool $dateDrift,
+        bool $matchedViaBundle,
+    ): array {
+        $reasons = [];
+
+        if ($thinDb) {
+            $reasons[] = 'existing_description_thin';
+        }
+        if ($matchedViaThinBucket) {
+            $reasons[] = 'matched_by_date_amount_bucket';
+        }
+        if ($matchedViaThinAmountOnly) {
+            $reasons[] = 'matched_by_amount_proximity';
+        }
+        if ($dateDrift) {
+            $reasons[] = 'statement_date_differs_from_ledger';
+        }
+        if ($matchedViaBundle) {
+            $reasons[] = 'matched_via_split_bundle';
+        }
+
+        return $reasons;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @param  array<int, string>  $needsDetailReasons
+     */
+    private function logNeedsDetailRow(
+        int $idx,
+        array $row,
+        int $accountId,
+        string $date,
+        ?string $ledgerTransactionDate,
+        float $amount,
+        int $existingId,
+        array $needsDetailReasons,
+        string $matchAttemptReason,
+        string $statementDescription,
+        string $ledgerDescription,
+    ): void {
+        try {
+            Log::info('Statement reconciliation row needs detail', [
+                'row_index' => $idx,
+                'statement_sequence' => $row['statement_sequence'] ?? null,
+                'account_id' => $accountId,
+                'statement_date' => $date,
+                'ledger_transaction_date' => $ledgerTransactionDate,
+                'amount' => $amount,
+                'type' => $row['type'] ?? null,
+                'existing_transaction_id' => $existingId,
+                'reasons' => $needsDetailReasons,
+                'match_attempt_reason' => $matchAttemptReason,
+                'statement_description_preview' => Str::limit($statementDescription, 160),
+                'ledger_description_preview' => Str::limit($ledgerDescription, 160),
+            ]);
+        } catch (\Throwable) {
+            // Reconciliation should never fail just because the log sink is unavailable.
+        }
+    }
+
+    /**
+     * Map parsed row index → ledger txn + bundle id when saved bundles fully match this upload.
+     *
+     * @return array<int, array{txn: Transaction, bundle_id: int}>
+     */
+    private function resolveBundleAssignments(array $parsedTransactions, int $accountId): array
+    {
+        $bundles = StatementLedgerBundle::query()
+            ->where('account_id', $accountId)
+            ->with(['rows'])
+            ->orderBy('id')
+            ->get();
+
+        /** @var array<int, array{txn: Transaction, bundle_id: int}> */
+        $assignments = [];
+
+        foreach ($bundles as $bundle) {
+            $ledger = Transaction::query()->with(['category.parent'])->find($bundle->ledger_transaction_id);
+            if ($ledger === null || (int) $ledger->account_id !== $accountId) {
+                continue;
+            }
+
+            $lines = $bundle->rows;
+            if ($lines->isEmpty()) {
+                continue;
+            }
+
+            $sumLines = round((float) $lines->sum(fn ($line) => (float) $line->amount), 2);
+            if (abs($sumLines - (float) $ledger->amount) > self::CHAIN_EPSILON) {
+                continue;
+            }
+
+            /** @var array<int, true> */
+            $parsedConsumed = [];
+            /** @var array<int, true> */
+            $matchedIdx = [];
+
+            foreach ($lines as $line) {
+                $lineDate = $line->statement_date instanceof Carbon
+                    ? $line->statement_date->format('Y-m-d')
+                    : Carbon::parse((string) $line->statement_date)->format('Y-m-d');
+
+                $foundIdx = null;
+                foreach ($parsedTransactions as $idx => $row) {
+                    if (isset($parsedConsumed[$idx])) {
+                        continue;
+                    }
+                    if (isset($assignments[$idx])) {
+                        continue;
+                    }
+
+                    $seq = $row['statement_sequence'] ?? null;
+                    if ($line->statement_sequence !== null) {
+                        if ($seq === null || (int) $seq !== (int) $line->statement_sequence) {
+                            continue;
+                        }
+                    }
+
+                    $rowDate = (string) ($row['date'] ?? '');
+                    if ($rowDate !== $lineDate) {
+                        continue;
+                    }
+
+                    if (abs((float) ($row['amount'] ?? 0) - (float) $line->amount) > self::CHAIN_EPSILON) {
+                        continue;
+                    }
+
+                    $foundIdx = $idx;
+                    break;
+                }
+
+                if ($foundIdx === null) {
+                    $matchedIdx = [];
+                    break;
+                }
+
+                $matchedIdx[$foundIdx] = true;
+                $parsedConsumed[$foundIdx] = true;
+            }
+
+            if ($matchedIdx === [] || count($matchedIdx) !== $lines->count()) {
+                continue;
+            }
+
+            foreach (array_keys($matchedIdx) as $idx) {
+                $assignments[(int) $idx] = ['txn' => $ledger, 'bundle_id' => (int) $bundle->id];
+            }
+        }
+
+        return $assignments;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $parsedTransactions
+     * @return array<int, int>
+     */
+    private function sortedStatementIndices(array $parsedTransactions): array
+    {
+        $n = count($parsedTransactions);
+        $indices = range(0, max(0, $n - 1));
+        usort($indices, function (int $a, int $b) use ($parsedTransactions): int {
+            $sa = $parsedTransactions[$a]['statement_sequence'] ?? null;
+            $sb = $parsedTransactions[$b]['statement_sequence'] ?? null;
+            if ($sa !== null && $sb !== null) {
+                return ((int) $sa) <=> ((int) $sb);
+            }
+            if ($sa !== null) {
+                return -1;
+            }
+            if ($sb !== null) {
+                return 1;
+            }
+
+            return $a <=> $b;
+        });
+
+        return $indices;
+    }
+
+    /**
+     * @param  array<int, Transaction>  $candidates
+     * @param  array<int, true>  $usedLedgerIds
+     */
+    private function pickNearestUnusedThin(
+        array $candidates,
+        string $statementDateYmd,
+        string $statementType,
+        array &$usedLedgerIds,
+        ?int $proximityMaxDays,
+    ): ?Transaction {
+        $eligible = [];
+        foreach ($candidates as $txn) {
+            if (isset($usedLedgerIds[$txn->id])) {
+                continue;
+            }
+            if (! $this->statementTypeMatchesLedger($statementType, (string) $txn->transaction_type)) {
+                continue;
+            }
+
+            $ledgerDate = $txn->transaction_date instanceof Carbon
+                ? $txn->transaction_date->format('Y-m-d')
+                : Carbon::parse((string) $txn->transaction_date)->format('Y-m-d');
+
+            $dayDist = 0;
+            if ($statementDateYmd !== '') {
+                try {
+                    $dayDist = (int) abs(Carbon::parse($statementDateYmd)->diffInDays(Carbon::parse($ledgerDate)));
+                } catch (\Throwable) {
+                    continue;
+                }
+            }
+
+            if ($proximityMaxDays !== null && $dayDist > $proximityMaxDays) {
+                continue;
+            }
+
+            $eligible[] = ['txn' => $txn, 'dist' => $dayDist];
+        }
+
+        if ($eligible === []) {
+            return null;
+        }
+
+        usort($eligible, function (array $a, array $b): int {
+            if ($a['dist'] !== $b['dist']) {
+                return $a['dist'] <=> $b['dist'];
+            }
+
+            return $a['txn']->id <=> $b['txn']->id;
+        });
+
+        return $eligible[0]['txn'];
+    }
+
+    private function statementTypeMatchesLedger(string $statementType, string $ledgerType): bool
+    {
+        return match ($statementType) {
+            'income' => $ledgerType === 'income',
+            'expense' => $ledgerType === 'expense',
+            default => false,
+        };
+    }
+
+    /**
+     * @param  Collection<int, Transaction>|\Illuminate\Database\Eloquent\Collection<int, Transaction>  $dbExpanded
+     * @param  array{start: string|null, end: string|null}  $period
+     * @return Collection<int, Transaction>
+     */
+    private function narrowDbTransactions(Collection $dbExpanded, array $period): Collection
+    {
+        if ($period['start'] === null || $period['end'] === null) {
+            return $dbExpanded;
+        }
+
+        return $dbExpanded->filter(function (Transaction $txn) use ($period): bool {
+            $d = $txn->transaction_date instanceof Carbon
+                ? $txn->transaction_date->format('Y-m-d')
+                : Carbon::parse((string) $txn->transaction_date)->format('Y-m-d');
+
+            return $d >= $period['start'] && $d <= $period['end'];
+        });
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $parsedTransactions
+     * @return array{start: string|null, end: string|null}
+     */
+    private function derivePeriod(array $parsedTransactions): array
+    {
+        $dates = [];
+        foreach ($parsedTransactions as $row) {
+            $d = $row['date'] ?? null;
+            if (is_string($d) && $d !== '') {
+                try {
+                    $dates[] = Carbon::parse($d)->format('Y-m-d');
+                } catch (\Throwable) {
+                    //
+                }
+            }
+        }
+        if ($dates === []) {
+            return ['start' => null, 'end' => null];
+        }
+
+        sort($dates);
+
+        return ['start' => $dates[0], 'end' => $dates[count($dates) - 1]];
+    }
+
+    private function thinDbBucketKey(string $dateYmd, float $amount): string
+    {
+        return $dateYmd.'_'.$this->matchKeys->formatAmountForKey($amount).'_thin_bucket';
+    }
+
+    /**
+     * Savings-account convention: balance_after = balance_before - debit + credit.
+     *
+     * @param  array<int, array<string, mixed>>  $sortedTransactions
+     * @return array<string, mixed>
+     */
+    private function computeBalanceSummary(
+        array $sortedTransactions,
+        ?int $accountId,
+        ?string $expandedStart,
+        ?string $expandedEnd,
+    ): array {
+        $rowsWithBalance = [];
+        foreach ($sortedTransactions as $i => $row) {
+            if (isset($row['balance_after']) && $row['balance_after'] !== null && is_numeric($row['balance_after'])) {
+                $rowsWithBalance[] = ['index' => $i, 'row' => $row];
+            }
+        }
+
+        if ($rowsWithBalance === []) {
+            return [
+                'chain_ok' => null,
+                'chain_skipped_reason' => 'no_balance_column',
+                'broken_at_statement_sequence' => null,
+                'broken_at_index' => null,
+                'derived_opening_before_first' => null,
+                'statement_closing_balance' => null,
+                'net_delta_statement_minus_db' => null,
+                'opening_matches_prior_row' => null,
+                'matches_initial_balance_txn' => null,
+                'broken_at_detail' => null,
+            ];
+        }
+
+        $first = $rowsWithBalance[0]['row'];
+        $firstIdx = $rowsWithBalance[0]['index'];
+        $debit0 = (float) ($first['debit_amount'] ?? 0);
+        $credit0 = (float) ($first['credit_amount'] ?? 0);
+        $bal0 = (float) $first['balance_after'];
+        $derivedOpening = round($bal0 + $debit0 - $credit0, 2);
+
+        $openingMatchesPriorRow = null;
+        if ($firstIdx > 0) {
+            $prior = $sortedTransactions[$firstIdx - 1];
+            if (isset($prior['balance_after']) && $prior['balance_after'] !== null && is_numeric($prior['balance_after'])) {
+                $openingMatchesPriorRow = abs((float) $prior['balance_after'] - $derivedOpening) <= self::CHAIN_EPSILON;
+            }
+        }
+
+        $chainOk = true;
+        $brokenAtIndex = null;
+        $brokenSeq = null;
+        $brokenDetail = null;
+
+        for ($k = 1; $k < count($rowsWithBalance); $k++) {
+            $prev = $rowsWithBalance[$k - 1];
+            $prevBal = (float) $prev['row']['balance_after'];
+            $curWithIndex = $rowsWithBalance[$k];
+            $cur = $curWithIndex['row'];
+            $debit = (float) ($cur['debit_amount'] ?? 0);
+            $credit = (float) ($cur['credit_amount'] ?? 0);
+            $expected = round($prevBal - $debit + $credit, 2);
+            $actual = round((float) $cur['balance_after'], 2);
+            if (abs($expected - $actual) > self::CHAIN_EPSILON) {
+                $chainOk = false;
+                $brokenAtIndex = $curWithIndex['index'];
+                $brokenSeq = $cur['statement_sequence'] ?? null;
+                $brokenDetail = [
+                    'previous_index' => $prev['index'],
+                    'previous_statement_sequence' => $prev['row']['statement_sequence'] ?? null,
+                    'previous_balance_after' => round($prevBal, 2),
+                    'current_index' => $curWithIndex['index'],
+                    'current_statement_sequence' => $cur['statement_sequence'] ?? null,
+                    'current_date' => $cur['date'] ?? null,
+                    'current_description' => $cur['description'] ?? null,
+                    'current_debit_amount' => round($debit, 2),
+                    'current_credit_amount' => round($credit, 2),
+                    'expected_balance_after' => $expected,
+                    'actual_balance_after' => $actual,
+                    'difference' => round($actual - $expected, 2),
+                ];
+                break;
+            }
+        }
+
+        $lastRow = $rowsWithBalance[count($rowsWithBalance) - 1]['row'];
+
+        $matchesInitialBalanceTxn = null;
+        if ($accountId !== null && $expandedStart !== null && $expandedEnd !== null) {
+            $patterns = config('statement.initial_balance_description_patterns', []);
+            $patterns = is_array($patterns) ? array_values(array_filter($patterns, fn ($p) => is_string($p) && $p !== '')) : [];
+
+            $matchesInitialBalanceTxn = false;
+            $candidates = Transaction::query()
+                ->where('account_id', $accountId)
+                ->whereDate('transaction_date', '>=', $expandedStart)
+                ->whereDate('transaction_date', '<=', $expandedEnd)
+                ->whereIn('transaction_type', ['income', 'expense'])
+                ->get(['amount', 'description']);
+
+            foreach ($candidates as $cand) {
+                $descLower = mb_strtolower((string) ($cand->description ?? ''));
+                foreach ($patterns as $p) {
+                    if ($descLower !== '' && str_contains($descLower, mb_strtolower($p))) {
+                        $matchesInitialBalanceTxn = true;
+                        break 2;
+                    }
+                }
+                if (abs((float) $cand->amount - $derivedOpening) <= self::CHAIN_EPSILON) {
+                    $matchesInitialBalanceTxn = true;
+                    break;
+                }
+            }
+        }
+
+        return [
+            'chain_ok' => $chainOk,
+            'chain_skipped_reason' => null,
+            'broken_at_statement_sequence' => $brokenSeq,
+            'broken_at_index' => $brokenAtIndex,
+            'derived_opening_before_first' => $derivedOpening,
+            'statement_closing_balance' => isset($lastRow['balance_after']) ? (float) $lastRow['balance_after'] : null,
+            'opening_matches_prior_row' => $openingMatchesPriorRow,
+            'matches_initial_balance_txn' => $matchesInitialBalanceTxn,
+            'broken_at_detail' => $brokenDetail,
+        ];
+    }
+
+    /**
+     * Category IDs from an existing ledger row for Review defaults (expense = parent + leaf).
+     *
+     * @return array{ledger_category_id: ?int, ledger_subcategory_id: ?int}
+     */
+    private function ledgerCategoryHints(?Transaction $match): array
+    {
+        if ($match === null || ! in_array($match->transaction_type, ['income', 'expense'], true)) {
+            return ['ledger_category_id' => null, 'ledger_subcategory_id' => null];
+        }
+
+        $leaf = $match->category;
+        if ($leaf === null) {
+            return ['ledger_category_id' => null, 'ledger_subcategory_id' => null];
+        }
+
+        if ($match->transaction_type === 'income') {
+            return ['ledger_category_id' => null, 'ledger_subcategory_id' => $leaf->id];
+        }
+
+        if ($leaf->parent_id !== null) {
+            return ['ledger_category_id' => (int) $leaf->parent_id, 'ledger_subcategory_id' => $leaf->id];
+        }
+
+        return ['ledger_category_id' => $leaf->id, 'ledger_subcategory_id' => null];
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $parsedTransactions
+     */
+    private function statementNetDelta(array $parsedTransactions): float
+    {
+        $sum = 0.0;
+        foreach ($parsedTransactions as $row) {
+            $sum += (float) ($row['credit_amount'] ?? 0) - (float) ($row['debit_amount'] ?? 0);
+        }
+
+        return round($sum, 2);
+    }
+
+    /**
+     * Net cash impact of ledger rows in the reconcile window (income minus expense magnitude).
+     *
+     * @param  Collection<int, Transaction>|\Illuminate\Database\Eloquent\Collection<int, Transaction>  $dbTxns
+     */
+    private function dbNetDelta(Collection $dbTxns): float
+    {
+        $sum = 0.0;
+        foreach ($dbTxns as $txn) {
+            if ($txn->transaction_type === 'income') {
+                $sum += (float) $txn->amount;
+            } else {
+                $sum -= (float) $txn->amount;
+            }
+        }
+
+        return round($sum, 2);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $parsedTransactions
+     * @return array<int, array<string, mixed>>
+     */
+    private function annotateUnscoped(array $parsedTransactions): array
+    {
+        $debugReconcile = (bool) config('statement.reconcile_debug', false);
+        $out = [];
+        foreach ($parsedTransactions as $row) {
+            $desc = (string) ($row['description'] ?? '');
+            $date = (string) ($row['date'] ?? '');
+            $amount = (float) ($row['amount'] ?? 0);
+            $merged = array_merge($row, [
+                'reconcile_status' => 'unscoped',
+                'existing_transaction_id' => null,
+                'match_key' => $this->matchKeys->matchKey($date, $amount, $desc),
+                'display_description' => $desc,
+                'db_description_snapshot' => null,
+                'db_reference_snapshot' => null,
+                'ledger_category_id' => null,
+                'ledger_subcategory_id' => null,
+                'date_drift' => false,
+                'ledger_transaction_date' => null,
+                'matched_via_bundle' => false,
+                'bundle_id' => null,
+                'needs_detail_reasons' => [],
+            ]);
+            if ($debugReconcile) {
+                $merged['match_attempt_reason'] = 'unscoped_account';
+            }
+            $out[] = $merged;
+        }
+
+        return $out;
+    }
+}

--- a/config/statement.php
+++ b/config/statement.php
@@ -24,4 +24,31 @@ return [
      */
     'csv_header_optional_substrings' => ['sr.no', 'sr no', 's.no'],
 
+    /*
+     * When reconciling statement rows to ledger, widen the DB query window by ±N calendar days so
+     * amount+description matches still resolve when sync/import dates disagree slightly from the bank file.
+     */
+    'reconcile_date_skew_days' => max(0, (int) env('STATEMENT_RECONCILE_DATE_SKEW_DAYS', 3)),
+
+    /*
+     * Optional max calendar distance between statement row date and thin-placeholder ledger rows when picking among
+     * multiple candidates (null = no extra radius filter beyond skew query window; ties broken by nearest date).
+     */
+    'reconcile_thin_proximity_max_days' => env('STATEMENT_RECONCILE_THIN_PROXIMITY_MAX_DAYS') !== null
+        ? max(0, (int) env('STATEMENT_RECONCILE_THIN_PROXIMITY_MAX_DAYS'))
+        : null,
+
+    /*
+     * When true, each reconcile row includes match_attempt_reason for troubleshooting (avoid in production UX noise).
+     */
+    'reconcile_debug' => (bool) env('STATEMENT_RECONCILE_DEBUG', false),
+
+    /*
+     * Informational only: descriptions matching these substrings (case-insensitive) suggest an opening-balance adjustment row.
+     */
+    'initial_balance_description_patterns' => [
+        'initial balance',
+        'opening balance',
+    ],
+
 ];

--- a/database/migrations/2026_05_02_120000_create_statement_ledger_bundles_tables.php
+++ b/database/migrations/2026_05_02_120000_create_statement_ledger_bundles_tables.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('statement_ledger_bundles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('account_id')->constrained('accounts')->cascadeOnDelete();
+            $table->foreignId('ledger_transaction_id')->constrained('transactions')->cascadeOnDelete();
+            $table->timestamps();
+        });
+
+        Schema::create('statement_ledger_bundle_rows', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('bundle_id')->constrained('statement_ledger_bundles')->cascadeOnDelete();
+            $table->unsignedInteger('statement_sequence')->nullable();
+            $table->date('statement_date');
+            $table->decimal('amount', 14, 2);
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('statement_ledger_bundle_rows');
+        Schema::dropIfExists('statement_ledger_bundles');
+    }
+};

--- a/resources/js/Pages/Statements/Review.jsx
+++ b/resources/js/Pages/Statements/Review.jsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useState } from 'react';
-import { Head, router } from '@inertiajs/react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Head, router, usePage } from '@inertiajs/react';
 import BootstrapLayout from '../../Layouts/BootstrapLayout';
 
 function childList(category) {
@@ -25,32 +25,275 @@ function rowHasLeafCategory(row, expenseParentsWithSubs) {
     return Boolean(row.subcategory_id);
 }
 
-export default function Review({ parsedData, suggestedAccount, accountMatch, accountMatchNote, accounts, categories }) {
+/** Prefill category dropdowns when we matched an existing ledger row. */
+function categoryDefaultsFromLedger(t) {
+    const lc = t.ledger_category_id != null ? String(t.ledger_category_id) : '';
+    const ls = t.ledger_subcategory_id != null ? String(t.ledger_subcategory_id) : '';
+    if (t.type === 'income') {
+        return { category_id: '', subcategory_id: ls };
+    }
+    return { category_id: lc, subcategory_id: ls };
+}
+
+function monthKeyFromRow(row) {
+    const d = row?.date;
+    if (!d || typeof d !== 'string') {
+        return 'unknown';
+    }
+    const key = d.slice(0, 7);
+    return /^\d{4}-\d{2}$/.test(key) ? key : 'unknown';
+}
+
+function sortedMonthKeys(transactionsList) {
+    const keys = [...new Set((transactionsList ?? []).map(monthKeyFromRow))].sort();
+    return keys.length ? keys : ['unknown'];
+}
+
+function activeMonthStorageKey() {
+    if (typeof window === 'undefined') {
+        return 'statement-review-active-month';
+    }
+    return `statement-review-active-month:${window.location.pathname}`;
+}
+
+function storedActiveMonth(monthKeys) {
+    if (typeof window === 'undefined') {
+        return monthKeys[0] ?? 'unknown';
+    }
+    const stored = window.sessionStorage.getItem(activeMonthStorageKey());
+    return stored && monthKeys.includes(stored) ? stored : monthKeys[0] ?? 'unknown';
+}
+
+function formatMonthTabLabel(monthKey) {
+    if (monthKey === 'unknown') {
+        return 'Unknown date';
+    }
+    const [y, m] = monthKey.split('-');
+    return new Date(parseInt(y, 10), parseInt(m, 10) - 1, 1).toLocaleString('en-IN', {
+        month: 'short',
+        year: 'numeric',
+    });
+}
+
+function reconcileSummaryForRows(rowSubset) {
+    const counts = { missing_in_db: 0, matched_complete: 0, matched_needs_enrichment: 0 };
+    for (const r of rowSubset) {
+        switch (r.reconcile_status) {
+            case 'missing_in_db':
+                counts.missing_in_db++;
+                break;
+            case 'matched_complete':
+                counts.matched_complete++;
+                break;
+            case 'matched_needs_enrichment':
+                counts.matched_needs_enrichment++;
+                break;
+            default:
+                break;
+        }
+    }
+    return counts;
+}
+
+/** @param {Record<string, string|string[]>|undefined} errors */
+function importFieldError(errors, rowId, field, orderedRowIds) {
+    if (!errors || !orderedRowIds?.length) {
+        return null;
+    }
+    const idx = orderedRowIds.indexOf(rowId);
+    if (idx < 0) {
+        return null;
+    }
+    const raw = errors[`rows.${idx}.${field}`];
+    if (Array.isArray(raw)) {
+        return raw[0] ?? null;
+    }
+    return raw ?? null;
+}
+
+/** @param {Record<string, string|string[]>|undefined} errors */
+function rowsLevelImportMessage(errors) {
+    if (!errors?.rows) {
+        return null;
+    }
+    return Array.isArray(errors.rows) ? errors.rows.join(' ') : errors.rows;
+}
+
+function reconcileRowSurface(row) {
+    if (row.matched_via_bundle) {
+        return { bg: '#f5f3ff', borderLeft: '4px solid #8b5cf6' };
+    }
+    switch (row.reconcile_status) {
+        case 'matched_complete':
+            return { bg: '#ecfdf5', borderLeft: '4px solid #10b981' };
+        case 'matched_needs_enrichment':
+            return { bg: '#fffbeb', borderLeft: '4px solid #f59e0b' };
+        case 'missing_in_db':
+            return { bg: '#fef2f2', borderLeft: '4px solid #ef4444' };
+        default:
+            return { bg: null, borderLeft: '4px solid transparent' };
+    }
+}
+
+const NEEDS_DETAIL_REASON_LABELS = {
+    existing_description_thin: 'Existing ledger description is thin',
+    matched_by_date_amount_bucket: 'Matched by date + amount only',
+    matched_by_amount_proximity: 'Matched by amount proximity',
+    statement_date_differs_from_ledger: 'Statement date differs from ledger date',
+    matched_via_split_bundle: 'Matched through split bundle',
+};
+
+function needsDetailReasonText(row) {
+    const reasons = Array.isArray(row.needs_detail_reasons) ? row.needs_detail_reasons : [];
+    return reasons
+        .map((reason) => NEEDS_DETAIL_REASON_LABELS[reason] ?? reason)
+        .filter(Boolean)
+        .join(', ');
+}
+
+function matchedLedgerRowId(row) {
+    if (row.reconcile_status !== 'matched_needs_enrichment' || !row.existing_transaction_id) {
+        return null;
+    }
+
+    return row.existing_transaction_id;
+}
+
+function matchedLedgerRowLabel(row) {
+    const id = matchedLedgerRowId(row);
+    return id ? `Matched DB row ID: #${id}` : null;
+}
+
+function matchedLedgerRowEditUrl(row) {
+    const id = matchedLedgerRowId(row);
+    return id ? `/transactions/${id}/edit` : null;
+}
+
+function formatRupee(value) {
+    if (value == null || value === '' || Number.isNaN(Number(value))) {
+        return '—';
+    }
+    return `₹${Number(value).toLocaleString('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+const IMPORT_ROW_ORDER_STORAGE_KEY = 'statement_review_import_row_order';
+
+export default function Review({
+    parsedData,
+    suggestedAccount,
+    accountMatch,
+    accountMatchNote,
+    accounts,
+    categories,
+    reconcilePeriod = {},
+    reconcileSummary = {},
+    reconcileDebug = false,
+}) {
     const { account_info, transactions } = parsedData;
     const ai = account_info ?? {};
 
+    const page = usePage();
+    const inertiaErrors = page.props.errors ?? {};
+    const flash = page.props.flash ?? {};
+
     const showVal = (v) => (v != null && String(v).trim() !== '' ? String(v) : '—');
 
+    const summary = reconcileSummary ?? {};
+    const balanceInfo = summary.balance ?? {};
+    const showBalanceCol = transactions.some((t) => t.balance_after != null && t.balance_after !== '');
+
+    const isImportableRow = (t) => t.reconcile_status === 'missing_in_db' || t.reconcile_status === 'unscoped';
+    const isNeedsDetailRow = (t) => t.reconcile_status === 'matched_needs_enrichment' && t.existing_transaction_id;
+    const defaultSelected = (t) => isImportableRow(t) || isNeedsDetailRow(t);
+
     const [rows, setRows] = useState(
-        transactions.map((t, i) => ({
-            ...t,
-            _id: i,
-            account_id: suggestedAccount?.id != null ? String(suggestedAccount.id) : '',
-            category_id: '',
-            subcategory_id: '',
-            aiLoading: false,
-            aiDone: false,
-            selected: true,
-        })),
+        transactions.map((t, i) => {
+            const cat = categoryDefaultsFromLedger(t);
+            return {
+                ...t,
+                _id: i,
+                account_id: suggestedAccount?.id != null ? String(suggestedAccount.id) : '',
+                category_id: cat.category_id,
+                subcategory_id: cat.subcategory_id,
+                aiLoading: false,
+                aiDone: false,
+                selected: defaultSelected(t),
+            };
+        }),
     );
     const [importing, setImporting] = useState(false);
+    const [enriching, setEnriching] = useState(false);
+    const [autoFixingDateId, setAutoFixingDateId] = useState(null);
+    const [bundleLedgerId, setBundleLedgerId] = useState('');
+    const [bundleLinking, setBundleLinking] = useState(false);
+
+    useEffect(() => {
+        setRows(
+            transactions.map((t, i) => {
+                const cat = categoryDefaultsFromLedger(t);
+                return {
+                    ...t,
+                    _id: i,
+                    account_id: suggestedAccount?.id != null ? String(suggestedAccount.id) : '',
+                    category_id: cat.category_id,
+                    subcategory_id: cat.subcategory_id,
+                    aiLoading: false,
+                    aiDone: false,
+                    selected: defaultSelected(t),
+                };
+            }),
+        );
+    }, [transactions, suggestedAccount?.id]);
+
+    const monthKeys = useMemo(() => sortedMonthKeys(rows), [rows]);
+
+    const [activeMonth, setActiveMonth] = useState(() => storedActiveMonth(sortedMonthKeys(transactions)));
+
+    useEffect(() => {
+        setActiveMonth((prev) => {
+            const keys = sortedMonthKeys(rows);
+            const stored = storedActiveMonth(keys);
+            return keys.includes(prev) ? prev : stored;
+        });
+    }, [rows]);
+
+    useEffect(() => {
+        if (typeof window !== 'undefined' && monthKeys.includes(activeMonth)) {
+            window.sessionStorage.setItem(activeMonthStorageKey(), activeMonth);
+        }
+    }, [activeMonth, monthKeys]);
+
+    const visibleRows = useMemo(
+        () => rows.filter((r) => monthKeyFromRow(r) === activeMonth),
+        [rows, activeMonth],
+    );
+
+    const monthSummary = useMemo(() => reconcileSummaryForRows(visibleRows), [visibleRows]);
+
+    const orderedIdsForImportErrors = useMemo(() => {
+        const hasRowFieldErrors = Object.keys(inertiaErrors).some((k) => /^rows\.\d+\.\w+$/.test(k));
+        if (!hasRowFieldErrors) {
+            return [];
+        }
+        try {
+            const raw = sessionStorage.getItem(IMPORT_ROW_ORDER_STORAGE_KEY);
+            const parsed = raw ? JSON.parse(raw) : [];
+            return Array.isArray(parsed) ? parsed.map(Number) : [];
+        } catch {
+            return [];
+        }
+    }, [inertiaErrors]);
 
     const incomeParent = useMemo(
-        () => categories.find((c) => c.code === 'INCOME'),
+        () => categories.find((c) => String(c.code ?? '').toUpperCase() === 'INCOME'),
         [categories],
     );
     const expenseParents = useMemo(
-        () => categories.filter((c) => c.code !== 'INCOME' && c.code !== 'ACCOUNTTR'),
+        () =>
+            categories.filter((c) => {
+                const code = String(c.code ?? '').toUpperCase();
+                return code !== 'INCOME' && code !== 'ACCOUNTTR';
+            }),
         [categories],
     );
     const expenseParentsWithSubs = useMemo(
@@ -78,7 +321,7 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                     Accept: 'application/json',
                     'X-CSRF-TOKEN': csrf(),
                 },
-                body: JSON.stringify({ description: row.description, type: row.type }),
+                body: JSON.stringify({ description: rowDescription(row), type: row.type }),
             });
             const data = await res.json();
             if (!res.ok) {
@@ -116,7 +359,7 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
     };
 
     const fillAllWithAI = async () => {
-        const unfilled = rows.filter(
+        const unfilled = visibleRows.filter(
             (r) => r.selected && !rowHasLeafCategory(r, expenseParentsWithSubs),
         );
         for (const row of unfilled) {
@@ -125,12 +368,12 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
     };
 
     const handleImport = () => {
-        const selected = rows.filter((r) => r.selected && r.account_id);
-        if (!selected.length) {
-            alert('Select at least one row with an account.');
+        const selectedForImport = visibleRows.filter((r) => r.selected && r.account_id && isImportableRow(r));
+        if (!selectedForImport.length) {
+            alert('Nothing to import in this month. Rows already marked “In ledger” are skipped.');
             return;
         }
-        const missingCat = selected.filter((r) => !rowHasLeafCategory(r, expenseParentsWithSubs));
+        const missingCat = selectedForImport.filter((r) => !rowHasLeafCategory(r, expenseParentsWithSubs));
         if (missingCat.length) {
             alert(
                 'Each selected row needs a valid leaf category: income rows require an income category; expense rows require a parent and subcategory where subs exist.',
@@ -139,27 +382,191 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
         }
         setImporting(true);
 
-        const payload = selected.map((r) => ({
+        const orderedIds = selectedForImport.map((r) => r._id);
+        sessionStorage.setItem(IMPORT_ROW_ORDER_STORAGE_KEY, JSON.stringify(orderedIds));
+
+        const payload = selectedForImport.map((r) => ({
             date: r.date,
-            description: r.description,
+            description: String(r.description || r.display_description || '').trim(),
             amount: r.amount,
             type: r.type,
             account_id: parseInt(r.account_id, 10),
             category_id: parseInt(r.subcategory_id || r.category_id, 10),
             reference: r.reference || null,
+            review_row_index: r._id,
         }));
 
         router.post('/statements/import', { rows: payload }, {
+            preserveScroll: true,
+            // router.post defaults preserveState:true — same Review instance keeps stale rows[] state after redirect.
+            preserveState: false,
             onFinish: () => setImporting(false),
+            onSuccess: () => sessionStorage.removeItem(IMPORT_ROW_ORDER_STORAGE_KEY),
         });
+    };
+
+    const visibleNeedsDetailRows = visibleRows.filter(isNeedsDetailRow);
+    const enrichmentCandidates = visibleNeedsDetailRows.filter((r) => r.selected);
+
+    const handleSaveEnrichment = () => {
+        if (!enrichmentCandidates.length) {
+            alert('Select at least one row marked “needs detail” to save descriptions.');
+            return;
+        }
+        setEnriching(true);
+        router.post(
+            '/statements/enrich',
+            {
+                updates: enrichmentCandidates.map((r) => ({
+                    transaction_id: r.existing_transaction_id,
+                    description: r.description || r.display_description,
+                    reference: r.reference ?? null,
+                    ...(r.date ? { transaction_date: r.date } : {}),
+                })),
+            },
+            {
+                preserveScroll: true,
+                preserveState: false,
+                onFinish: () => setEnriching(false),
+            },
+        );
+    };
+
+    const handleAutoFixDate = (row) => {
+        const transactionId = matchedLedgerRowId(row);
+        if (!transactionId || !row.date) {
+            return;
+        }
+
+        const description = String(row.db_description_snapshot || rowDescription(row)).trim();
+        if (!description) {
+            alert('Cannot auto-fix date because this ledger row has no description. Open the edit page and add details manually.');
+            return;
+        }
+
+        setAutoFixingDateId(row._id);
+        router.post(
+            '/statements/enrich',
+            {
+                updates: [
+                    {
+                        transaction_id: transactionId,
+                        description,
+                        reference: row.db_reference_snapshot || row.reference || null,
+                        transaction_date: row.date,
+                    },
+                ],
+            },
+            {
+                preserveScroll: true,
+                preserveState: false,
+                onFinish: () => setAutoFixingDateId(null),
+            },
+        );
+    };
+
+    const handleBundleLink = () => {
+        const selected = visibleRows.filter((r) => r.selected);
+        if (selected.length < 2) {
+            alert('Select at least two statement rows in this month to link as a split bundle.');
+            return;
+        }
+        const ledgerId = parseInt(bundleLedgerId, 10);
+        if (!ledgerId) {
+            alert('Enter the ledger transaction ID this bundle should match (from Transactions).');
+            return;
+        }
+        const accountIds = [...new Set(selected.map((r) => r.account_id).filter(Boolean))];
+        if (accountIds.length !== 1) {
+            alert('All selected rows must use the same account.');
+            return;
+        }
+        setBundleLinking(true);
+        router.post(
+            '/statements/bundle-link',
+            {
+                account_id: parseInt(accountIds[0], 10),
+                ledger_transaction_id: ledgerId,
+                rows: selected.map((r) => ({
+                    statement_sequence:
+                        r.statement_sequence != null && r.statement_sequence !== ''
+                            ? parseInt(r.statement_sequence, 10)
+                            : null,
+                    date: r.date,
+                    amount: parseFloat(r.amount),
+                    type: r.type,
+                    description: r.description ?? r.display_description ?? null,
+                })),
+            },
+            {
+                preserveScroll: true,
+                preserveState: false,
+                onFinish: () => setBundleLinking(false),
+            },
+        );
+    };
+
+    const rowDescription = (row) => row.display_description ?? row.description ?? '';
+
+    const reconcileBadge = (row) => {
+        if (row.matched_via_bundle) {
+            return { label: 'Split bundle', className: 'text-white', style: { backgroundColor: '#7c3aed' } };
+        }
+        switch (row.reconcile_status) {
+            case 'missing_in_db':
+                return { label: 'New / anomaly', className: 'bg-danger' };
+            case 'matched_complete':
+                return { label: 'In ledger', className: 'bg-success' };
+            case 'matched_needs_enrichment':
+                return { label: 'Needs detail', className: 'bg-warning text-dark' };
+            case 'unscoped':
+                return { label: 'Pick account', className: 'bg-info text-dark' };
+            default:
+                return null;
+        }
     };
 
     const confidenceColor = { high: '#10b981', medium: '#f59e0b', low: '#ef4444' };
     const selectedCount = rows.filter((r) => r.selected).length;
+    const visibleSelectedCount = visibleRows.filter((r) => r.selected).length;
+    const visibleImportableRows = visibleRows.filter((r) => isImportableRow(r));
+    const visibleImportableSelectedCount = visibleImportableRows.filter((r) => r.selected && r.account_id).length;
+    const selectedOutsideActiveMonth = rows.some(
+        (r) => r.selected && monthKeyFromRow(r) !== activeMonth,
+    );
+    const activeMonthIdx = monthKeys.indexOf(activeMonth);
 
+    const rowFieldErrorKeys = Object.keys(inertiaErrors).filter((k) => /^rows\.\d+\./.test(k));
+    const visibleRowIds = new Set(visibleRows.map((r) => r._id));
+    const rowFieldErrorsApplyToVisibleRows = rowFieldErrorKeys.length > 0 &&
+        orderedIdsForImportErrors.some((id) => visibleRowIds.has(id));
+    const rowsImportAlert = rowsLevelImportMessage(inertiaErrors);
+    const showImportErrorAlert = rowFieldErrorsApplyToVisibleRows || Boolean(rowsImportAlert && visibleImportableSelectedCount > 0);
+    const allVisibleRowsAlreadyInLedger = visibleRows.length > 0 && visibleImportableRows.length === 0;
     return (
         <BootstrapLayout>
             <Head title="Review Imported Statement" />
+
+            {flash.success ? (
+                <div className="alert alert-success mb-3" style={{ borderRadius: 10 }}>
+                    <i className="fas fa-check-circle me-2"></i>
+                    {flash.success}
+                </div>
+            ) : null}
+            {flash.warning ? (
+                <div className="alert alert-warning mb-3" style={{ borderRadius: 10 }}>
+                    <i className="fas fa-exclamation-triangle me-2"></i>
+                    {flash.warning}
+                </div>
+            ) : null}
+            {showImportErrorAlert && (
+                <div className="alert alert-danger mb-3" style={{ borderRadius: 10 }}>
+                    {rowsImportAlert ? <div className="mb-1">{rowsImportAlert}</div> : null}
+                    <div className="small mb-0">
+                        Fix the highlighted importable rows below (validation applies to your last import attempt).
+                    </div>
+                </div>
+            )}
 
             <div
                 className="card mb-4"
@@ -256,16 +663,181 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                 </div>
             )}
 
+            {reconcilePeriod?.start && reconcilePeriod?.end && (
+                <div className="alert alert-light border mb-3" style={{ borderRadius: 10 }}>
+                    <strong className="me-2">
+                        <i className="fas fa-calendar-alt me-1 text-primary"></i>
+                        Reconcile period (from statement rows)
+                    </strong>
+                    <span className="text-muted">
+                        {reconcilePeriod.start} → {reconcilePeriod.end}
+                    </span>
+                    <div className="mt-2 d-flex flex-wrap gap-2 align-items-center small">
+                        <span className="badge bg-secondary text-white">
+                            Month view: {formatMonthTabLabel(activeMonth)}
+                        </span>
+                        <span className="badge bg-danger">New / anomaly: {monthSummary.missing_in_db ?? 0}</span>
+                        <span className="badge bg-success">In ledger: {monthSummary.matched_complete ?? 0}</span>
+                        <span className="badge bg-warning text-dark">
+                            Needs detail: {monthSummary.matched_needs_enrichment ?? 0}
+                        </span>
+                        {balanceInfo.net_delta_statement_minus_db != null &&
+                            Math.abs(Number(balanceInfo.net_delta_statement_minus_db)) > 0.001 && (
+                                <span className="badge bg-dark">
+                                    Statement vs ledger net (period): ₹
+                                    {Number(balanceInfo.net_delta_statement_minus_db).toLocaleString('en-IN', {
+                                        minimumFractionDigits: 2,
+                                    })}
+                                </span>
+                            )}
+                    </div>
+                    <div className="small text-muted mt-2 mb-0">
+                        Counts above reflect <strong>{formatMonthTabLabel(activeMonth)}</strong> only ({visibleRows.length}{' '}
+                        rows in the table). Statement-wide reconcile period: {reconcilePeriod.start} →{' '}
+                        {reconcilePeriod.end}. Bank date wins when you save descriptions; date-drift rows need Save
+                        descriptions (or edit the date manually). Row colors: green = already recorded · red = missing from
+                        ledger · amber = needs ledger fix (thin description and/or bank date correction).
+                    </div>
+                </div>
+            )}
+
+            {balanceInfo.chain_ok === false && (
+                <div className="alert alert-danger mb-3" style={{ borderRadius: 10 }}>
+                    <strong>Balance mismatch on statement</strong>
+                    <div className="small mt-1">
+                        Running balances do not chain correctly at statement sequence{' '}
+                        {balanceInfo.broken_at_statement_sequence != null
+                            ? `#${balanceInfo.broken_at_statement_sequence}`
+                            : `(row index ${balanceInfo.broken_at_index})`}
+                        . This is the statement row number from the source file, not a transaction ID.
+                    </div>
+                    {balanceInfo.broken_at_detail ? (
+                        <div className="mt-2 p-2 bg-white border rounded small text-dark">
+                            <div className="fw-semibold mb-1">Mismatch detail</div>
+                            <div className="row g-2">
+                                <div className="col-md-3">
+                                    <span className="text-muted">Previous row:</span>{' '}
+                                    #{balanceInfo.broken_at_detail.previous_statement_sequence ?? balanceInfo.broken_at_detail.previous_index}
+                                </div>
+                                <div className="col-md-3">
+                                    <span className="text-muted">Previous balance:</span>{' '}
+                                    {formatRupee(balanceInfo.broken_at_detail.previous_balance_after)}
+                                </div>
+                                <div className="col-md-3">
+                                    <span className="text-muted">Current row:</span>{' '}
+                                    #{balanceInfo.broken_at_detail.current_statement_sequence ?? balanceInfo.broken_at_detail.current_index}
+                                </div>
+                                <div className="col-md-3">
+                                    <span className="text-muted">Date:</span>{' '}
+                                    {showVal(balanceInfo.broken_at_detail.current_date)}
+                                </div>
+                                <div className="col-md-6">
+                                    <span className="text-muted">Description:</span>{' '}
+                                    {showVal(balanceInfo.broken_at_detail.current_description)}
+                                </div>
+                                <div className="col-md-3">
+                                    <span className="text-muted">Debit:</span>{' '}
+                                    {formatRupee(balanceInfo.broken_at_detail.current_debit_amount)}
+                                </div>
+                                <div className="col-md-3">
+                                    <span className="text-muted">Credit:</span>{' '}
+                                    {formatRupee(balanceInfo.broken_at_detail.current_credit_amount)}
+                                </div>
+                                <div className="col-md-4">
+                                    <span className="text-muted">Expected balance:</span>{' '}
+                                    {formatRupee(balanceInfo.broken_at_detail.expected_balance_after)}
+                                </div>
+                                <div className="col-md-4">
+                                    <span className="text-muted">Actual balance:</span>{' '}
+                                    {formatRupee(balanceInfo.broken_at_detail.actual_balance_after)}
+                                </div>
+                                <div className="col-md-4">
+                                    <span className="text-muted">Difference:</span>{' '}
+                                    {formatRupee(balanceInfo.broken_at_detail.difference)}
+                                </div>
+                            </div>
+                            <div className="text-muted mt-2">
+                                Formula checked: previous balance - debit + credit = expected balance.
+                            </div>
+                        </div>
+                    ) : null}
+                </div>
+            )}
+
+            <div className="card mb-3 border-0 shadow-sm" style={{ borderRadius: 12 }}>
+                <div className="card-body py-3">
+                    <div className="d-flex flex-wrap align-items-center gap-2 mb-2">
+                        <span className="small text-muted fw-semibold text-uppercase me-2">Statement month</span>
+                        <button
+                            type="button"
+                            className="btn btn-sm btn-outline-secondary"
+                            disabled={activeMonthIdx <= 0}
+                            onClick={() => activeMonthIdx > 0 && setActiveMonth(monthKeys[activeMonthIdx - 1])}
+                        >
+                            <i className="fas fa-chevron-left"></i>
+                        </button>
+                        <span className="fw-bold px-2">{formatMonthTabLabel(activeMonth)}</span>
+                        <button
+                            type="button"
+                            className="btn btn-sm btn-outline-secondary"
+                            disabled={activeMonthIdx < 0 || activeMonthIdx >= monthKeys.length - 1}
+                            onClick={() =>
+                                activeMonthIdx >= 0 &&
+                                activeMonthIdx < monthKeys.length - 1 &&
+                                setActiveMonth(monthKeys[activeMonthIdx + 1])
+                            }
+                        >
+                            <i className="fas fa-chevron-right"></i>
+                        </button>
+                        <span className="small text-muted ms-2">{visibleRows.length} rows</span>
+                    </div>
+                    <div className="d-flex flex-wrap gap-2">
+                        {monthKeys.map((mk) => {
+                            const cnt = rows.filter((r) => monthKeyFromRow(r) === mk).length;
+                            const active = mk === activeMonth;
+                            return (
+                                <button
+                                    key={mk}
+                                    type="button"
+                                    className={`btn btn-sm ${active ? 'btn-primary' : 'btn-outline-secondary'}`}
+                                    style={{ borderRadius: 20 }}
+                                    onClick={() => setActiveMonth(mk)}
+                                >
+                                    {formatMonthTabLabel(mk)}
+                                    <span className={`badge ms-2 ${active ? 'bg-light text-primary' : 'bg-secondary'}`}>
+                                        {cnt}
+                                    </span>
+                                </button>
+                            );
+                        })}
+                    </div>
+                </div>
+            </div>
+
+            {selectedOutsideActiveMonth ? (
+                <div className="alert alert-info py-2 mb-3 small" style={{ borderRadius: 10 }}>
+                    You have selections in other months. Import, Save descriptions, bundle link, and AI batch actions
+                    apply only to <strong>{formatMonthTabLabel(activeMonth)}</strong>.
+                </div>
+            ) : null}
+
             <div className="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
                 <div>
                     <h5 className="mb-0 fw-bold">
                         <i className="fas fa-table me-2" style={{ color: '#667eea' }}></i>
                         Review Transactions
                         <span className="badge ms-2" style={{ background: '#667eea', fontSize: 12 }}>
-                            {selectedCount} selected
+                            {visibleSelectedCount} selected · {selectedCount} total
                         </span>
                     </h5>
-                    <small className="text-muted">Review, edit categories, then import</small>
+                    <small className="text-muted d-block mt-1">
+                        Import only applies to red “New / anomaly” rows. Green “In ledger” rows are duplicates and are skipped.
+                    </small>
+                    {allVisibleRowsAlreadyInLedger ? (
+                        <div className="alert alert-success py-2 mt-2 mb-0 small" style={{ borderRadius: 10 }}>
+                            All {visibleRows.length} rows in {formatMonthTabLabel(activeMonth)} are already in ledger. Nothing to import.
+                        </div>
+                    ) : null}
                 </div>
                 <div className="d-flex gap-2">
                     <button
@@ -280,12 +852,70 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                             fontSize: 13,
                         }}
                     >
-                        <i className="fas fa-magic me-2"></i>Assign categories (AI) — all rows
+                        <i className="fas fa-magic me-2"></i>Assign categories (AI) — visible month
                     </button>
+                    {(monthSummary.matched_needs_enrichment ?? 0) > 0 && (
+                        <button
+                            type="button"
+                            onClick={handleSaveEnrichment}
+                            disabled={enriching || enrichmentCandidates.length === 0}
+                            className="btn btn-outline-dark"
+                            style={{
+                                borderRadius: 8,
+                                fontWeight: 600,
+                                fontSize: 13,
+                            }}
+                            title="Save statement narratives onto selected rows marked ‘Needs detail’."
+                        >
+                            {enriching ? (
+                                <>
+                                    <span className="spinner-border spinner-border-sm me-2"></span>
+                                    Saving...
+                                </>
+                            ) : (
+                                <>
+                                    <i className="fas fa-save me-2"></i>
+                                    Save descriptions ({enrichmentCandidates.length})
+                                </>
+                            )}
+                        </button>
+                    )}
+                    <div className="d-flex align-items-center gap-2 flex-wrap">
+                        <input
+                            type="number"
+                            min={1}
+                            className="form-control form-control-sm"
+                            style={{ width: 140, borderRadius: 8 }}
+                            placeholder="Ledger txn ID"
+                            value={bundleLedgerId}
+                            onChange={(e) => setBundleLedgerId(e.target.value)}
+                            title="Transactions list ID for one ledger row whose amount equals the sum of selected rows"
+                        />
+                        <button
+                            type="button"
+                            onClick={handleBundleLink}
+                            disabled={bundleLinking || visibleRows.filter((r) => r.selected).length < 2}
+                            className="btn btn-outline-secondary btn-sm"
+                            style={{ borderRadius: 8, fontWeight: 600, fontSize: 13 }}
+                            title="Save when multiple bank lines map to one ledger amount (e.g. ₹20+₹10 → ₹30). Re-upload statement after saving."
+                        >
+                            {bundleLinking ? (
+                                <>
+                                    <span className="spinner-border spinner-border-sm me-2"></span>
+                                    Saving bundle...
+                                </>
+                            ) : (
+                                <>
+                                    <i className="fas fa-link me-2"></i>
+                                    Link split rows ({visibleRows.filter((r) => r.selected).length})
+                                </>
+                            )}
+                        </button>
+                    </div>
                     <button
                         type="button"
                         onClick={handleImport}
-                        disabled={importing || !selectedCount}
+                        disabled={importing || visibleImportableSelectedCount === 0}
                         className="btn"
                         style={{
                             background: 'linear-gradient(135deg,#667eea,#764ba2)',
@@ -303,7 +933,7 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                         ) : (
                             <>
                                 <i className="fas fa-download me-2"></i>
-                                Import {selectedCount} Rows
+                                Import {visibleImportableSelectedCount} Rows
                             </>
                         )}
                     </button>
@@ -319,26 +949,88 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                                     <input
                                         type="checkbox"
                                         className="form-check-input"
-                                        checked={rows.length > 0 && rows.every((r) => r.selected)}
-                                        onChange={(e) => setRows((prev) => prev.map((r) => ({ ...r, selected: e.target.checked })))}
+                                        checked={
+                                            visibleRows.length > 0 &&
+                                            visibleRows.every((r) => r.selected)
+                                        }
+                                        onChange={(e) => {
+                                            const checked = e.target.checked;
+                                            const ids = new Set(visibleRows.map((r) => r._id));
+                                            setRows((prev) =>
+                                                prev.map((r) =>
+                                                    ids.has(r._id) ? { ...r, selected: checked } : r,
+                                                ),
+                                            );
+                                        }}
                                     />
                                 </th>
+                                <th style={{ padding: '12px 16px', fontWeight: 600, letterSpacing: '0.03em' }}>STATUS</th>
                                 <th style={{ padding: '12px 16px', fontWeight: 600, letterSpacing: '0.03em' }}>DATE</th>
                                 <th style={{ padding: '12px 16px', fontWeight: 600, letterSpacing: '0.03em' }}>DESCRIPTION</th>
+                                {showBalanceCol && (
+                                    <th style={{ padding: '12px 16px', fontWeight: 600, letterSpacing: '0.03em' }}>
+                                        BALANCE
+                                    </th>
+                                )}
                                 <th style={{ padding: '12px 16px', fontWeight: 600, letterSpacing: '0.03em' }}>AMOUNT</th>
                                 <th style={{ padding: '12px 16px', fontWeight: 600, letterSpacing: '0.03em' }}>TYPE</th>
                                 <th style={{ padding: '12px 16px', fontWeight: 600, letterSpacing: '0.03em' }}>ACCOUNT</th>
                                 <th style={{ padding: '12px 16px', fontWeight: 600, letterSpacing: '0.03em' }}>CATEGORY</th>
                                 <th style={{ padding: '12px 16px', fontWeight: 600, letterSpacing: '0.03em' }}>ACTION</th>
+                                {reconcileDebug && (
+                                    <th style={{ padding: '12px 16px', fontWeight: 600, letterSpacing: '0.03em' }}>
+                                        MATCH DEBUG
+                                    </th>
+                                )}
                             </tr>
                         </thead>
                         <tbody>
-                            {rows.map((row) => (
+                            {visibleRows.map((row) => {
+                                const surface = reconcileRowSurface(row);
+                                const rowBg = surface.bg ?? (row.selected ? '#fff' : '#f9fafb');
+                                const accountErr = importFieldError(
+                                    inertiaErrors,
+                                    row._id,
+                                    'account_id',
+                                    orderedIdsForImportErrors,
+                                );
+                                const categoryErr = importFieldError(
+                                    inertiaErrors,
+                                    row._id,
+                                    'category_id',
+                                    orderedIdsForImportErrors,
+                                );
+                                const descriptionErr = importFieldError(
+                                    inertiaErrors,
+                                    row._id,
+                                    'description',
+                                    orderedIdsForImportErrors,
+                                );
+                                const amountErr = importFieldError(
+                                    inertiaErrors,
+                                    row._id,
+                                    'amount',
+                                    orderedIdsForImportErrors,
+                                );
+                                const dateErr = importFieldError(
+                                    inertiaErrors,
+                                    row._id,
+                                    'date',
+                                    orderedIdsForImportErrors,
+                                );
+                                const typeErr = importFieldError(
+                                    inertiaErrors,
+                                    row._id,
+                                    'type',
+                                    orderedIdsForImportErrors,
+                                );
+                                return (
                                 <tr
                                     key={row._id}
                                     style={{
-                                        background: row.selected ? '#fff' : '#f9fafb',
+                                        background: rowBg,
                                         borderBottom: '1px solid #f1f5f9',
+                                        borderLeft: surface.borderLeft,
                                         opacity: row.selected ? 1 : 0.55,
                                         transition: 'background 0.15s',
                                     }}
@@ -351,8 +1043,74 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                                             onChange={(e) => updateRow(row._id, 'selected', e.target.checked)}
                                         />
                                     </td>
+                                    <td style={{ padding: '12px 16px', verticalAlign: 'middle' }}>
+                                        {(() => {
+                                            const b = reconcileBadge(row);
+                                            const reasonText = needsDetailReasonText(row);
+                                            const matchedLedgerText = matchedLedgerRowLabel(row);
+                                            const matchedLedgerUrl = matchedLedgerRowEditUrl(row);
+                                            const badgeTitle = [reasonText, matchedLedgerText].filter(Boolean).join(' • ') || undefined;
+                                            return b ? (
+                                                <>
+                                                    <span
+                                                        className={`badge ${b.className}`}
+                                                        style={{ fontSize: 10, ...(b.style ?? {}) }}
+                                                        title={badgeTitle}
+                                                    >
+                                                        {b.label}
+                                                    </span>
+                                                    {reasonText && row.reconcile_status === 'matched_needs_enrichment' ? (
+                                                        <div className="small text-muted mt-1" style={{ fontSize: 10, maxWidth: 170 }}>
+                                                            Why: {reasonText}
+                                                        </div>
+                                                    ) : null}
+                                                    {matchedLedgerUrl ? (
+                                                        <div className="small text-muted mt-1" style={{ fontSize: 10, maxWidth: 170 }}>
+                                                            Matched DB row:{' '}
+                                                            <a
+                                                                className="link-primary text-decoration-underline"
+                                                                href={matchedLedgerUrl}
+                                                                style={{ fontSize: 10 }}
+                                                                title={`Open transaction #${matchedLedgerRowId(row)} edit page`}
+                                                            >
+                                                                #{matchedLedgerRowId(row)}
+                                                            </a>
+                                                        </div>
+                                                    ) : null}
+                                                </>
+                                            ) : (
+                                                '—'
+                                            );
+                                        })()}
+                                    </td>
                                     <td style={{ padding: '12px 16px', verticalAlign: 'middle', whiteSpace: 'nowrap' }}>
-                                        <span style={{ color: '#475569', fontWeight: 500 }}>{row.date}</span>
+                                        <div className="d-flex align-items-center gap-2">
+                                            <span style={{ color: '#475569', fontWeight: 500 }}>{row.date}</span>
+                                            {row.date_drift && matchedLedgerRowId(row) ? (
+                                                <button
+                                                    type="button"
+                                                    className="btn btn-sm btn-outline-warning p-1"
+                                                    style={{ lineHeight: 1, borderRadius: 8 }}
+                                                    title={`Auto-fix ledger date from ${row.ledger_transaction_date || 'old date'} to statement date ${row.date}`}
+                                                    onClick={() => handleAutoFixDate(row)}
+                                                    disabled={autoFixingDateId === row._id}
+                                                >
+                                                    {autoFixingDateId === row._id ? (
+                                                        <span className="spinner-border spinner-border-sm" style={{ width: 12, height: 12 }}></span>
+                                                    ) : (
+                                                        <i className="fas fa-magic"></i>
+                                                    )}
+                                                </button>
+                                            ) : null}
+                                        </div>
+                                        {row.date_drift && row.ledger_transaction_date ? (
+                                            <div className="small text-warning-emphasis mt-1" style={{ fontSize: 10 }}>
+                                                Ledger: {row.ledger_transaction_date}
+                                            </div>
+                                        ) : null}
+                                        {dateErr ? (
+                                            <div className="text-danger small mt-1 text-wrap">{dateErr}</div>
+                                        ) : null}
                                     </td>
                                     <td style={{ padding: '12px 16px', verticalAlign: 'middle', maxWidth: 260 }}>
                                         <div
@@ -363,9 +1121,9 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                                                 textOverflow: 'ellipsis',
                                                 whiteSpace: 'nowrap',
                                             }}
-                                            title={row.description}
+                                            title={rowDescription(row)}
                                         >
-                                            {row.description}
+                                            {rowDescription(row)}
                                         </div>
                                         {row.aiReason && (
                                             <small style={{ color: confidenceColor[row.aiConfidence] || '#64748b', fontSize: 10 }}>
@@ -373,7 +1131,24 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                                                 {row.aiReason}
                                             </small>
                                         )}
+                                        {descriptionErr ? (
+                                            <div className="text-danger small mt-1">{descriptionErr}</div>
+                                        ) : null}
                                     </td>
+                                    {showBalanceCol && (
+                                        <td style={{ padding: '12px 16px', verticalAlign: 'middle', whiteSpace: 'nowrap' }}>
+                                            {row.balance_after != null ? (
+                                                <span style={{ color: '#475569', fontWeight: 600, fontSize: 12 }}>
+                                                    ₹
+                                                    {parseFloat(row.balance_after).toLocaleString('en-IN', {
+                                                        minimumFractionDigits: 2,
+                                                    })}
+                                                </span>
+                                            ) : (
+                                                <span className="text-muted">—</span>
+                                            )}
+                                        </td>
+                                    )}
                                     <td style={{ padding: '12px 16px', verticalAlign: 'middle', whiteSpace: 'nowrap' }}>
                                         <span
                                             style={{
@@ -384,6 +1159,9 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                                         >
                                             ₹{parseFloat(row.amount).toLocaleString('en-IN', { minimumFractionDigits: 2 })}
                                         </span>
+                                        {amountErr ? (
+                                            <div className="text-danger small mt-1">{amountErr}</div>
+                                        ) : null}
                                     </td>
                                     <td style={{ padding: '12px 16px', verticalAlign: 'middle' }}>
                                         <span
@@ -398,10 +1176,13 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                                         >
                                             {row.type === 'income' ? '▲ Income' : '▼ Expense'}
                                         </span>
+                                        {typeErr ? (
+                                            <div className="text-danger small mt-1">{typeErr}</div>
+                                        ) : null}
                                     </td>
                                     <td style={{ padding: '8px 12px', verticalAlign: 'middle', minWidth: 160 }}>
                                         <select
-                                            className="form-select form-select-sm"
+                                            className={`form-select form-select-sm${accountErr ? ' is-invalid' : ''}`}
                                             value={row.account_id}
                                             onChange={(e) => updateRow(row._id, 'account_id', e.target.value)}
                                             style={{ borderRadius: 8, border: '1px solid #e2e8f0', fontSize: 12 }}
@@ -411,11 +1192,14 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                                                 <option key={a.id} value={a.id}>{a.name}</option>
                                             ))}
                                         </select>
+                                        {accountErr ? (
+                                            <div className="invalid-feedback d-block">{accountErr}</div>
+                                        ) : null}
                                     </td>
                                     <td style={{ padding: '8px 12px', verticalAlign: 'middle', minWidth: 200 }}>
                                         {row.type === 'income' ? (
                                             <select
-                                                className="form-select form-select-sm"
+                                                className={`form-select form-select-sm${categoryErr ? ' is-invalid' : ''}`}
                                                 value={row.subcategory_id}
                                                 onChange={(e) => {
                                                     updateRow(row._id, 'category_id', '');
@@ -431,7 +1215,7 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                                         ) : (
                                             <div className="d-flex flex-column gap-1">
                                                 <select
-                                                    className="form-select form-select-sm"
+                                                    className={`form-select form-select-sm${categoryErr ? ' is-invalid' : ''}`}
                                                     value={row.category_id}
                                                     onChange={(e) => {
                                                         updateRow(row._id, 'category_id', e.target.value);
@@ -446,7 +1230,7 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                                                 </select>
                                                 {row.category_id && getSubcategories(row.category_id).length > 0 && (
                                                     <select
-                                                        className="form-select form-select-sm"
+                                                        className={`form-select form-select-sm${categoryErr ? ' is-invalid' : ''}`}
                                                         value={row.subcategory_id}
                                                         onChange={(e) => updateRow(row._id, 'subcategory_id', e.target.value)}
                                                         style={{ borderRadius: 8, border: '1px solid #e2e8f0', fontSize: 12 }}
@@ -459,6 +1243,9 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                                                 )}
                                             </div>
                                         )}
+                                        {categoryErr ? (
+                                            <div className="invalid-feedback d-block">{categoryErr}</div>
+                                        ) : null}
                                         {row.aiDone && row.aiConfidence && (
                                             <div style={{ marginTop: 2 }}>
                                                 <span
@@ -516,8 +1303,23 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                                             )}
                                         </button>
                                     </td>
+                                    {reconcileDebug && (
+                                        <td
+                                            style={{
+                                                padding: '8px 12px',
+                                                verticalAlign: 'middle',
+                                                fontSize: 10,
+                                                color: '#64748b',
+                                                maxWidth: 140,
+                                                wordBreak: 'break-word',
+                                            }}
+                                        >
+                                            {row.match_attempt_reason ?? '—'}
+                                        </td>
+                                    )}
                                 </tr>
-                            ))}
+                                );
+                            })}
                         </tbody>
                     </table>
                 </div>
@@ -539,7 +1341,7 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                             <i className="fas fa-arrow-up me-1" style={{ color: '#10b981' }}></i>
                             Income: ₹
                             {rows
-                                .filter((r) => r.type === 'income' && r.selected)
+                                .filter((r) => monthKeyFromRow(r) === activeMonth && r.type === 'income' && r.selected)
                                 .reduce((s, r) => s + parseFloat(r.amount), 0)
                                 .toLocaleString('en-IN', { minimumFractionDigits: 2 })}
                         </span>
@@ -547,7 +1349,7 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                             <i className="fas fa-arrow-down me-1" style={{ color: '#ef4444' }}></i>
                             Expense: ₹
                             {rows
-                                .filter((r) => r.type === 'expense' && r.selected)
+                                .filter((r) => monthKeyFromRow(r) === activeMonth && r.type === 'expense' && r.selected)
                                 .reduce((s, r) => s + parseFloat(r.amount), 0)
                                 .toLocaleString('en-IN', { minimumFractionDigits: 2 })}
                         </span>
@@ -555,7 +1357,7 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                     <button
                         type="button"
                         onClick={handleImport}
-                        disabled={importing || !selectedCount}
+                        disabled={importing || visibleImportableSelectedCount === 0}
                         style={{
                             padding: '10px 28px',
                             borderRadius: 10,
@@ -568,7 +1370,7 @@ export default function Review({ parsedData, suggestedAccount, accountMatch, acc
                         }}
                     >
                         <i className="fas fa-download me-2"></i>
-                        Import {selectedCount} Transaction{selectedCount !== 1 ? 's' : ''}
+                        Import {visibleImportableSelectedCount} Transaction{visibleImportableSelectedCount !== 1 ? 's' : ''}
                     </button>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -74,5 +74,15 @@ Route::post('/ai/categorize', [AiController::class, 'categorize'])->name('ai.cat
 
 // Bank statement import
 Route::get('/statements/upload', [StatementController::class, 'uploadPage'])->name('statements.upload');
+Route::get('/statements/review', [StatementController::class, 'review'])->name('statements.review');
+Route::get('/statements/process', function () {
+    if (session()->has('statement_review_snapshot')) {
+        return redirect()->route('statements.review');
+    }
+
+    return redirect()->route('statements.upload');
+});
 Route::post('/statements/process', [StatementController::class, 'process'])->name('statements.process');
 Route::post('/statements/import', [StatementController::class, 'importTransactions'])->name('statements.import');
+Route::post('/statements/enrich', [StatementController::class, 'enrichTransactions'])->name('statements.enrich');
+Route::post('/statements/bundle-link', [StatementController::class, 'bundleLink'])->name('statements.bundle-link');

--- a/tests/Feature/AiCategorizeTest.php
+++ b/tests/Feature/AiCategorizeTest.php
@@ -182,7 +182,7 @@ class AiCategorizeTest extends TestCase
         ]);
 
         $response = $this->postJson('/ai/categorize', [
-            'description' => 'INDUSIND CREDIT CARD PAYMENT/XXXXXXXXXXXX6183',
+            'description' => 'DEMO CREDIT CARD PAYMENT/XXXXXXXXXXXX0000',
             'type' => 'expense',
         ]);
 
@@ -230,7 +230,7 @@ class AiCategorizeTest extends TestCase
         ]);
 
         $response = $this->postJson('/ai/categorize', [
-            'description' => 'INDUSIND CREDIT CARD PAYMENT/XXXXXXXXXXXX6183',
+            'description' => 'DEMO CREDIT CARD PAYMENT/XXXXXXXXXXXX0000',
             'type' => 'expense',
         ]);
 
@@ -278,7 +278,7 @@ class AiCategorizeTest extends TestCase
         ]);
 
         $response = $this->postJson('/ai/categorize', [
-            'description' => 'INDUSIND CREDIT CARD PAYMENT/XXXXXXXXXXXX6183',
+            'description' => 'DEMO CREDIT CARD PAYMENT/XXXXXXXXXXXX0000',
             'type' => 'expense',
         ]);
 

--- a/tests/Feature/StatementContentSplitterTest.php
+++ b/tests/Feature/StatementContentSplitterTest.php
@@ -9,22 +9,22 @@ class StatementContentSplitterTest extends TestCase
 {
     public function test_split_csv_finds_preamble_and_table(): void
     {
-        $raw = (string) file_get_contents(base_path('tests/fixtures/statement_indus_sample.csv'));
+        $raw = (string) file_get_contents(base_path('tests/fixtures/statement_demo_sample.csv'));
         $splitter = new StatementContentSplitter;
         $split = $splitter->splitCsvContent($raw);
 
-        $this->assertStringContainsString('INDB0000732', $split['preamble']);
+        $this->assertStringContainsString('TEST0001234', $split['preamble']);
         $this->assertStringContainsString('Sr.No.', $split['table_csv'] ?? '');
         $this->assertNotNull($split['header_line_index']);
     }
 
     public function test_split_pdf_text_uses_same_header_detection(): void
     {
-        $raw = (string) file_get_contents(base_path('tests/fixtures/statement_indus_sample.csv'));
+        $raw = (string) file_get_contents(base_path('tests/fixtures/statement_demo_sample.csv'));
         $splitter = new StatementContentSplitter;
         $split = $splitter->splitPdfText($raw);
 
-        $this->assertStringContainsString('INDB0000732', $split['preamble']);
+        $this->assertStringContainsString('TEST0001234', $split['preamble']);
         $this->assertStringContainsString('Sr.No.', $split['body']);
     }
 }

--- a/tests/Feature/StatementImportTest.php
+++ b/tests/Feature/StatementImportTest.php
@@ -34,7 +34,7 @@ class StatementImportTest extends TestCase
                         'account_holder_name' => 'Sample Holder',
                         'bank_name' => 'Sample Bank',
                         'account_number' => '100036608561',
-                        'ifsc_code' => 'INDB0000732',
+                        'ifsc_code' => 'TEST0001234',
                         'account_type' => 'savings',
                         'statement_period' => 'Mar 2026',
                     ],
@@ -53,17 +53,124 @@ class StatementImportTest extends TestCase
             'account_number' => '100036608561',
         ]);
 
-        $path = base_path('tests/fixtures/statement_indus_sample.csv');
+        $path = base_path('tests/fixtures/statement_demo_sample.csv');
         $file = new UploadedFile($path, 'statement.csv', 'text/csv', null, true);
 
         $this->post('/statements/process', ['statement' => $file])
+            ->assertRedirect(route('statements.review'));
+
+        $this->get(route('statements.review'))
             ->assertOk()
             ->assertInertia(fn (AssertableInertia $page) => $page
                 ->component('Statements/Review', false)
                 ->where('suggestedAccount.id', $account->id)
                 ->where('accountMatch', 'full_number')
                 ->has('accountMatchNote')
+                ->has('reconcilePeriod')
+                ->has('reconcileSummary')
             );
+    }
+
+    public function test_review_loads_multi_month_snapshot_from_session(): void
+    {
+        $snapshot = [
+            'parsedData' => [
+                'account_info' => [],
+                'transactions' => [
+                    [
+                        'date' => '2026-01-15',
+                        'description' => 'Jan row',
+                        'amount' => 10,
+                        'type' => 'expense',
+                        'reconcile_status' => 'missing_in_db',
+                    ],
+                    [
+                        'date' => '2026-02-15',
+                        'description' => 'Feb row',
+                        'amount' => 20,
+                        'type' => 'expense',
+                        'reconcile_status' => 'missing_in_db',
+                    ],
+                ],
+            ],
+            'reconcilePeriod' => ['start' => '2026-01-15', 'end' => '2026-02-15'],
+            'reconcileSummary' => [
+                'missing_in_db' => 2,
+                'matched_complete' => 0,
+                'matched_needs_enrichment' => 0,
+            ],
+            'reconcileDebug' => false,
+            'suggestedAccount' => null,
+            'accountMatch' => null,
+            'accountMatchNote' => null,
+            'suggested_account_id' => null,
+        ];
+
+        $this->withSession(['statement_review_snapshot' => $snapshot])
+            ->get(route('statements.review'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Statements/Review', false)
+                ->has('parsedData.transactions', 2)
+            );
+    }
+
+    public function test_import_validation_redirects_to_review_with_field_errors_when_snapshot_present(): void
+    {
+        $parent = Category::factory()->parent()->create(['is_active' => true]);
+        $child = Category::factory()->create(['parent_id' => $parent->id, 'is_active' => true]);
+        $account = Account::factory()->create([
+            'is_active' => true,
+            'current_balance' => 10000,
+            'opening_balance' => 10000,
+        ]);
+
+        $snapshot = [
+            'parsedData' => [
+                'account_info' => [],
+                'transactions' => [
+                    [
+                        'date' => '2026-01-15',
+                        'description' => 'NEFT TEST',
+                        'amount' => 250.50,
+                        'type' => 'expense',
+                        'reconcile_status' => 'missing_in_db',
+                    ],
+                ],
+            ],
+            'reconcilePeriod' => ['start' => '2026-01-15', 'end' => '2026-01-15'],
+            'reconcileSummary' => [
+                'missing_in_db' => 1,
+                'matched_complete' => 0,
+                'matched_needs_enrichment' => 0,
+            ],
+            'reconcileDebug' => false,
+            'suggestedAccount' => $account->only(['id', 'name', 'account_number', 'bank_name']),
+            'accountMatch' => 'full_number',
+            'accountMatchNote' => null,
+            'suggested_account_id' => $account->id,
+        ];
+
+        $missingId = max($child->id + 1000, 999_999);
+
+        $this->withSession(['statement_review_snapshot' => $snapshot])
+            ->from(route('statements.review'))
+            ->post('/statements/import', [
+                'rows' => [
+                    [
+                        'date' => '2026-01-15',
+                        'description' => 'NEFT TEST',
+                        'amount' => 250.50,
+                        'type' => 'expense',
+                        'account_id' => $account->id,
+                        'category_id' => $missingId,
+                        'reference' => null,
+                        'review_row_index' => 0,
+                    ],
+                ],
+            ])
+            ->assertRedirect(route('statements.review'))
+            ->assertSessionHasErrors('rows.0.category_id');
     }
 
     public function test_import_creates_transactions_and_updates_balance(): void
@@ -86,6 +193,7 @@ class StatementImportTest extends TestCase
                     'account_id' => $account->id,
                     'category_id' => $child->id,
                     'reference' => 'UTR123',
+                    'review_row_index' => 0,
                 ],
             ],
         ]);
@@ -119,11 +227,126 @@ class StatementImportTest extends TestCase
                     'type' => 'expense',
                     'account_id' => $account->id,
                     'category_id' => $child->id,
+                    'review_row_index' => 0,
                 ],
             ],
         ]);
 
+        $response->assertRedirect(route('statements.upload'));
         $response->assertSessionHasErrors('rows');
         $this->assertSame(0, Transaction::query()->count());
+    }
+
+    public function test_import_accepts_income_row_when_income_root_code_is_lowercase_like_seeder(): void
+    {
+        $incomeRoot = Category::factory()->parent()->create(['code' => 'income', 'is_active' => true]);
+        $incomeLeaf = Category::factory()->create(['parent_id' => $incomeRoot->id, 'is_active' => true]);
+        $account = Account::factory()->create([
+            'is_active' => true,
+            'current_balance' => 10000,
+            'opening_balance' => 10000,
+        ]);
+
+        $response = $this->post('/statements/import', [
+            'rows' => [
+                [
+                    'date' => '2026-01-15',
+                    'description' => 'Salary credit',
+                    'amount' => 5000,
+                    'type' => 'income',
+                    'account_id' => $account->id,
+                    'category_id' => $incomeLeaf->id,
+                    'reference' => null,
+                    'review_row_index' => 0,
+                ],
+            ],
+        ]);
+
+        $response->assertRedirect(route('transactions.index'));
+        $this->assertDatabaseHas('transactions', [
+            'account_id' => $account->id,
+            'category_id' => $incomeLeaf->id,
+            'transaction_type' => 'income',
+            'amount' => '5000.00',
+        ]);
+    }
+
+    public function test_import_rejects_two_identical_rows_in_one_request(): void
+    {
+        $parent = Category::factory()->parent()->create(['is_active' => true]);
+        $child = Category::factory()->create(['parent_id' => $parent->id, 'is_active' => true]);
+        $account = Account::factory()->create([
+            'is_active' => true,
+            'current_balance' => 10000,
+            'opening_balance' => 10000,
+        ]);
+
+        $row = [
+            'date' => '2026-01-15',
+            'description' => 'Dup test payment',
+            'amount' => 99.5,
+            'type' => 'expense',
+            'account_id' => $account->id,
+            'category_id' => $child->id,
+            'reference' => null,
+            'review_row_index' => 0,
+        ];
+
+        $this->from(route('statements.review'))
+            ->post('/statements/import', [
+                'rows' => [
+                    $row,
+                    array_replace($row, ['review_row_index' => 1]),
+                ],
+            ])
+            ->assertSessionHasErrors([
+                'rows.0.description',
+                'rows.0.amount',
+                'rows.1.description',
+                'rows.1.amount',
+            ]);
+
+        $this->assertSame(0, Transaction::query()->count());
+    }
+
+    public function test_import_rejects_row_matching_existing_ledger_transaction(): void
+    {
+        $parent = Category::factory()->parent()->create(['is_active' => true]);
+        $child = Category::factory()->create(['parent_id' => $parent->id, 'is_active' => true]);
+        $account = Account::factory()->create([
+            'is_active' => true,
+            'current_balance' => 10000,
+            'opening_balance' => 10000,
+        ]);
+
+        Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $child->id,
+            'transaction_type' => 'expense',
+            'amount' => 42.25,
+            'description' => 'Existing   UPI txn',
+            'transaction_date' => '2026-02-01',
+            'payment_method' => 'Bank Transfer',
+            'reference_number' => 'REF001',
+        ]);
+
+        $this->from(route('statements.review'))
+            ->post('/statements/import', [
+                'rows' => [
+                    [
+                        'date' => '2026-02-01',
+                        'description' => 'existing upi txn',
+                        'amount' => 42.25,
+                        'type' => 'expense',
+                        'account_id' => $account->id,
+                        'category_id' => $child->id,
+                        'reference' => 'ref001',
+                        'review_row_index' => 0,
+                    ],
+                ],
+            ])
+            ->assertSessionHasErrors(['rows.0.description', 'rows.0.amount']);
+
+        $this->assertSame(1, Transaction::query()->count());
     }
 }

--- a/tests/Feature/StatementParserServiceTest.php
+++ b/tests/Feature/StatementParserServiceTest.php
@@ -13,46 +13,29 @@ use Tests\TestCase;
 
 class StatementParserServiceTest extends TestCase
 {
-    public function test_parse_csv_merges_llm_account_info_and_php_transactions(): void
+    public function test_parse_csv_uses_preamble_account_info_and_php_transactions(): void
     {
-        Prism::fake([
-            new TextResponse(
-                steps: collect([]),
-                text: json_encode([
-                    'account_info' => [
-                        'account_holder_name' => 'Sample Holder',
-                        'bank_name' => 'Sample Bank',
-                        'account_number' => '100036608561',
-                        'ifsc_code' => 'INDB0000732',
-                        'account_type' => 'savings',
-                        'statement_period' => 'Mar 2026',
-                    ],
-                ]),
-                finishReason: FinishReason::Stop,
-                toolCalls: [],
-                toolResults: [],
-                usage: new Usage(0, 0),
-                meta: new Meta('fake', 'fake'),
-                messages: collect([]),
-            ),
-        ]);
-
-        $path = base_path('tests/fixtures/statement_indus_sample.csv');
+        $path = base_path('tests/fixtures/statement_demo_sample.csv');
         $file = new UploadedFile($path, 'statement.csv', 'text/csv', null, true);
 
         $service = new StatementParserService;
         $result = $service->parse($file);
 
-        $this->assertSame('Sample Holder', $result['account_info']['account_holder_name']);
-        $this->assertSame('INDB0000732', $result['account_info']['ifsc_code']);
+        $this->assertSame('DEMO STATEMENT USER', $result['account_info']['account_holder_name']);
+        $this->assertSame('100036608561', $result['account_info']['account_number']);
+        $this->assertSame('TEST0001234', $result['account_info']['ifsc_code']);
         $this->assertCount(2, $result['transactions']);
 
         $this->assertSame('2026-03-22', $result['transactions'][0]['date']);
         $this->assertSame('income', $result['transactions'][0]['type']);
         $this->assertEqualsWithDelta(23250.0, $result['transactions'][0]['amount'], 0.01);
+        $this->assertEqualsWithDelta(252758.24, (float) $result['transactions'][0]['balance_after'], 0.01);
+        $this->assertSame(1, $result['transactions'][0]['statement_sequence']);
 
         $this->assertSame('expense', $result['transactions'][1]['type']);
         $this->assertEqualsWithDelta(624.29, $result['transactions'][1]['amount'], 0.01);
+        $this->assertEqualsWithDelta(252133.95, (float) $result['transactions'][1]['balance_after'], 0.01);
+        $this->assertSame(2, $result['transactions'][1]['statement_sequence']);
     }
 
     public function test_comma_inside_description_does_not_shift_debit_into_credit(): void
@@ -95,6 +78,8 @@ CSV;
         $this->assertEqualsWithDelta(2305.63, $row['amount'], 0.01);
         $this->assertStringContainsString('CURSOR', $row['description']);
         $this->assertStringContainsString('AI POWERED', $row['description']);
+        $this->assertEqualsWithDelta(249828.32, (float) $row['balance_after'], 0.01);
+        $this->assertSame(3, $row['statement_sequence']);
     }
 
     public function test_preamble_key_value_lines_fill_account_info_when_llm_returns_nulls(): void
@@ -121,15 +106,15 @@ CSV;
             ),
         ]);
 
-        $path = base_path('tests/fixtures/statement_indus_sample.csv');
+        $path = base_path('tests/fixtures/statement_demo_sample.csv');
         $file = new UploadedFile($path, 'statement.csv', 'text/csv', null, true);
 
         $service = new StatementParserService;
         $result = $service->parse($file);
 
-        $this->assertSame('SAMPLE USER', $result['account_info']['account_holder_name']);
+        $this->assertSame('DEMO STATEMENT USER', $result['account_info']['account_holder_name']);
         $this->assertSame('100036608561', $result['account_info']['account_number']);
-        $this->assertSame('INDB0000732', $result['account_info']['ifsc_code']);
-        $this->assertStringContainsString('Mar 22', (string) $result['account_info']['statement_period']);
+        $this->assertSame('TEST0001234', $result['account_info']['ifsc_code']);
+        $this->assertStringContainsString('Mar', (string) $result['account_info']['statement_period']);
     }
 }

--- a/tests/Feature/StatementReconcileTest.php
+++ b/tests/Feature/StatementReconcileTest.php
@@ -1,0 +1,701 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\StatementLedgerBundle;
+use App\Models\Transaction;
+use App\Services\StatementReconciliationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
+use Inertia\Testing\AssertableInertia;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Text\Response as TextResponse;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
+use Tests\TestCase;
+
+class StatementReconcileTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function prismResponse(array $accountInfo): TextResponse
+    {
+        return new TextResponse(
+            steps: collect([]),
+            text: json_encode(['account_info' => $accountInfo]),
+            finishReason: FinishReason::Stop,
+            toolCalls: [],
+            toolResults: [],
+            usage: new Usage(0, 0),
+            meta: new Meta('fake', 'fake'),
+            messages: collect([]),
+        );
+    }
+
+    public function test_process_flags_balance_chain_when_statement_balances_do_not_continue(): void
+    {
+        Prism::fake([
+            $this->prismResponse([
+                'account_holder_name' => null,
+                'bank_name' => null,
+                'account_number' => '111122223333',
+                'ifsc_code' => null,
+                'account_type' => null,
+                'statement_period' => null,
+            ]),
+        ]);
+
+        $path = base_path('tests/fixtures/statement_demo_broken_balance.csv');
+        $file = new UploadedFile($path, 'statement.csv', 'text/csv', null, true);
+
+        $this->post('/statements/process', ['statement' => $file])
+            ->assertRedirect(route('statements.review'));
+
+        $this->get(route('statements.review'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('reconcileSummary.balance.chain_ok', false)
+                ->where('reconcileSummary.balance.broken_at_statement_sequence', 2)
+                ->where('reconcileSummary.balance.broken_at_detail.previous_statement_sequence', 1)
+                ->where('reconcileSummary.balance.broken_at_detail.current_statement_sequence', 2)
+                ->where('reconcileSummary.balance.broken_at_detail.current_date', '2026-03-22')
+                ->where('reconcileSummary.balance.broken_at_detail.current_description', 'DEMO CREDIT CARD PAYMENT/XXXXXXXXXXXX0000')
+                ->where('reconcileSummary.balance.broken_at_detail.current_debit_amount', 624.29)
+                ->where('reconcileSummary.balance.broken_at_detail.previous_balance_after', 252758.24)
+                ->where('reconcileSummary.balance.broken_at_detail.expected_balance_after', 252133.95)
+                ->where('reconcileSummary.balance.broken_at_detail.actual_balance_after', 252000)
+                ->where('reconcileSummary.balance.broken_at_detail.difference', -133.95)
+            );
+    }
+
+    public function test_process_reconcile_summary_counts_matches_and_missing_rows(): void
+    {
+        Prism::fake([
+            $this->prismResponse([
+                'account_holder_name' => 'Sample Holder',
+                'bank_name' => 'Sample Bank',
+                'account_number' => '100036608561',
+                'ifsc_code' => 'TEST0001234',
+                'account_type' => 'savings',
+                'statement_period' => 'Mar 2026',
+            ]),
+        ]);
+
+        $account = Account::factory()->create([
+            'is_active' => true,
+            'account_number' => '100036608561',
+            'current_balance' => 250000,
+            'opening_balance' => 250000,
+        ]);
+
+        $incomeRoot = Category::factory()->parent()->create(['code' => 'INCOME', 'is_active' => true]);
+        $incomeChild = Category::factory()->create(['parent_id' => $incomeRoot->id, 'is_active' => true]);
+        $expParent = Category::factory()->parent()->create(['code' => 'FOOD', 'is_active' => true]);
+        $expChild = Category::factory()->create(['parent_id' => $expParent->id, 'is_active' => true]);
+
+        Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $incomeChild->id,
+            'transaction_type' => 'income',
+            'amount' => 23250,
+            'description' => 'UPI/900000000001/CR/DEMO/TEST/demo@okbank/Mar',
+            'transaction_date' => '2026-03-22',
+            'payment_method' => 'Bank Transfer',
+            'reference_number' => null,
+        ]);
+
+        Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $expChild->id,
+            'transaction_type' => 'expense',
+            'amount' => 624.29,
+            'description' => 'Synced from external DB',
+            'transaction_date' => '2026-03-22',
+            'payment_method' => 'Bank Transfer',
+            'reference_number' => null,
+        ]);
+
+        $this->assertSame(
+            2,
+            Transaction::query()
+                ->where('account_id', $account->id)
+                ->whereDate('transaction_date', '>=', '2026-03-22')
+                ->whereDate('transaction_date', '<=', '2026-03-22')
+                ->count(),
+        );
+
+        $path = base_path('tests/fixtures/statement_demo_sample.csv');
+        $file = new UploadedFile($path, 'statement.csv', 'text/csv', null, true);
+
+        $this->post('/statements/process', ['statement' => $file])
+            ->assertRedirect(route('statements.review'));
+
+        $this->get(route('statements.review'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('reconcileSummary.balance.chain_ok', true)
+                ->where('reconcileSummary.matched_complete', 1)
+                ->where('reconcileSummary.matched_needs_enrichment', 1)
+                ->where('reconcileSummary.missing_in_db', 0)
+                ->where('reconcilePeriod.start', '2026-03-22')
+                ->where('reconcilePeriod.end', '2026-03-22')
+            );
+    }
+
+    public function test_enrich_updates_existing_transactions(): void
+    {
+        $account = Account::factory()->create(['is_active' => true, 'current_balance' => 10000, 'opening_balance' => 10000]);
+        $expParent = Category::factory()->parent()->create(['code' => 'FOOD', 'is_active' => true]);
+        $expChild = Category::factory()->create(['parent_id' => $expParent->id, 'is_active' => true]);
+
+        $txn = Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $expChild->id,
+            'transaction_type' => 'expense',
+            'amount' => 624.29,
+            'description' => 'Synced from external DB',
+            'transaction_date' => '2026-03-22',
+            'payment_method' => 'Bank Transfer',
+            'reference_number' => null,
+        ]);
+
+        $response = $this->post('/statements/enrich', [
+            'updates' => [
+                [
+                    'transaction_id' => $txn->id,
+                    'description' => 'DEMO CREDIT CARD PAYMENT/XXXXXXXXXXXX0000',
+                    'reference' => '2',
+                ],
+            ],
+        ]);
+
+        $response->assertRedirect();
+        $txn->refresh();
+        $this->assertStringContainsString('DEMO CREDIT CARD', $txn->description);
+        $this->assertSame('2', $txn->reference_number);
+    }
+
+    public function test_reconcile_fallback_matches_when_statement_date_skews_from_ledger(): void
+    {
+        $account = Account::factory()->create(['is_active' => true, 'current_balance' => 10000, 'opening_balance' => 10000]);
+        $expParent = Category::factory()->parent()->create(['code' => 'FOOD', 'is_active' => true]);
+        $expChild = Category::factory()->create(['parent_id' => $expParent->id, 'is_active' => true]);
+
+        Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $expChild->id,
+            'transaction_type' => 'expense',
+            'amount' => 412,
+            'description' => 'UPI/777777777777/SKEWTEST UNIQUE DESC SEGMENT',
+            'transaction_date' => '2026-02-28',
+            'payment_method' => 'Bank Transfer',
+            'reference_number' => 'LEDGER-REF-1',
+        ]);
+
+        $svc = app(StatementReconciliationService::class);
+        $parsed = [
+            [
+                'date' => '2026-03-01',
+                'description' => 'UPI/777777777777/SKEWTEST UNIQUE DESC SEGMENT',
+                'amount' => 412.0,
+                'type' => 'expense',
+                'reference' => null,
+                'debit_amount' => 412.0,
+                'credit_amount' => 0.0,
+            ],
+        ];
+
+        $result = $svc->analyze($parsed, $account->id);
+
+        $this->assertSame('matched_needs_enrichment', $result['transactions'][0]['reconcile_status']);
+        $this->assertTrue($result['transactions'][0]['date_drift']);
+        $this->assertSame('2026-02-28', $result['transactions'][0]['ledger_transaction_date']);
+        $this->assertSame('UPI/777777777777/SKEWTEST UNIQUE DESC SEGMENT', $result['transactions'][0]['db_description_snapshot']);
+        $this->assertSame('LEDGER-REF-1', $result['transactions'][0]['db_reference_snapshot']);
+        $this->assertNotNull($result['transactions'][0]['existing_transaction_id']);
+        $this->assertContains('statement_date_differs_from_ledger', $result['transactions'][0]['needs_detail_reasons']);
+    }
+
+    public function test_reconcile_fallback_does_not_match_when_secondary_fingerprint_is_ambiguous(): void
+    {
+        $account = Account::factory()->create(['is_active' => true, 'current_balance' => 10000, 'opening_balance' => 10000]);
+        $expParent = Category::factory()->parent()->create(['code' => 'FOOD', 'is_active' => true]);
+        $expChild = Category::factory()->create(['parent_id' => $expParent->id, 'is_active' => true]);
+        $sameDesc = 'UPI/888888888888/AMBIGUOUS SKEWTEST';
+
+        Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $expChild->id,
+            'transaction_type' => 'expense',
+            'amount' => 100,
+            'description' => $sameDesc,
+            'transaction_date' => '2026-02-27',
+            'payment_method' => 'Bank Transfer',
+            'reference_number' => null,
+        ]);
+        Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $expChild->id,
+            'transaction_type' => 'expense',
+            'amount' => 100,
+            'description' => $sameDesc,
+            'transaction_date' => '2026-03-02',
+            'payment_method' => 'Bank Transfer',
+            'reference_number' => null,
+        ]);
+
+        $svc = app(StatementReconciliationService::class);
+        $parsed = [
+            [
+                'date' => '2026-03-01',
+                'description' => $sameDesc,
+                'amount' => 100.0,
+                'type' => 'expense',
+                'reference' => null,
+                'debit_amount' => 100.0,
+                'credit_amount' => 0.0,
+            ],
+        ];
+
+        $result = $svc->analyze($parsed, $account->id);
+
+        $this->assertSame('missing_in_db', $result['transactions'][0]['reconcile_status']);
+        $this->assertNull($result['transactions'][0]['existing_transaction_id']);
+        $this->assertFalse($result['transactions'][0]['date_drift']);
+        $this->assertSame([], $result['transactions'][0]['needs_detail_reasons']);
+    }
+
+    public function test_enrich_updates_transaction_date_when_provided(): void
+    {
+        $account = Account::factory()->create(['is_active' => true, 'current_balance' => 10000, 'opening_balance' => 10000]);
+        $expParent = Category::factory()->parent()->create(['code' => 'FOOD', 'is_active' => true]);
+        $expChild = Category::factory()->create(['parent_id' => $expParent->id, 'is_active' => true]);
+
+        $txn = Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $expChild->id,
+            'transaction_type' => 'expense',
+            'amount' => 624.29,
+            'description' => 'Synced from external DB',
+            'transaction_date' => '2026-03-22',
+            'payment_method' => 'Bank Transfer',
+            'reference_number' => null,
+        ]);
+
+        $response = $this->post('/statements/enrich', [
+            'updates' => [
+                [
+                    'transaction_id' => $txn->id,
+                    'description' => 'DEMO CREDIT CARD PAYMENT/XXXXXXXXXXXX0000',
+                    'reference' => '2',
+                    'transaction_date' => '2026-03-23',
+                ],
+            ],
+        ]);
+
+        $response->assertRedirect();
+        $txn->refresh();
+        $this->assertSame('2026-03-23', $txn->transaction_date->format('Y-m-d'));
+    }
+
+    public function test_enrich_rechecks_review_snapshot_and_turns_needs_detail_into_in_ledger(): void
+    {
+        $account = Account::factory()->create(['is_active' => true, 'current_balance' => 10000, 'opening_balance' => 10000]);
+        $expParent = Category::factory()->parent()->create(['code' => 'FOOD', 'is_active' => true]);
+        $expChild = Category::factory()->create(['parent_id' => $expParent->id, 'is_active' => true]);
+
+        $txn = Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $expChild->id,
+            'transaction_type' => 'expense',
+            'amount' => 412,
+            'description' => 'Synced from external DB',
+            'transaction_date' => '2026-02-28',
+            'payment_method' => 'Bank Transfer',
+            'reference_number' => null,
+        ]);
+
+        $parsed = [
+            [
+                'date' => '2026-03-01',
+                'description' => 'UPI/777777777777/SKEWTEST UNIQUE DESC SEGMENT',
+                'amount' => 412.0,
+                'type' => 'expense',
+                'reference' => null,
+                'debit_amount' => 412.0,
+                'credit_amount' => 0.0,
+            ],
+        ];
+
+        $svc = app(StatementReconciliationService::class);
+        $before = $svc->analyze($parsed, $account->id);
+        $this->assertSame('matched_needs_enrichment', $before['transactions'][0]['reconcile_status']);
+
+        $response = $this->withSession([
+            'statement_review_snapshot' => [
+                'parsedData' => [
+                    'account_info' => [],
+                    'transactions' => $before['transactions'],
+                ],
+                'reconcilePeriod' => $before['period'],
+                'reconcileSummary' => $before['summary'],
+                'reconcileDebug' => false,
+                'suggestedAccount' => $account->only(['id', 'name', 'account_number', 'bank_name']),
+                'accountMatch' => 'full_number',
+                'accountMatchNote' => null,
+                'suggested_account_id' => $account->id,
+            ],
+        ])->post('/statements/enrich', [
+            'updates' => [
+                [
+                    'transaction_id' => $txn->id,
+                    'description' => 'UPI/777777777777/SKEWTEST UNIQUE DESC SEGMENT',
+                    'reference' => null,
+                    'transaction_date' => '2026-03-01',
+                ],
+            ],
+        ]);
+
+        $response->assertRedirect('/statements/review');
+        $snapshot = session('statement_review_snapshot');
+        $this->assertSame('matched_complete', $snapshot['parsedData']['transactions'][0]['reconcile_status']);
+        $this->assertSame(1, $snapshot['reconcileSummary']['matched_complete']);
+        $this->assertSame(0, $snapshot['reconcileSummary']['matched_needs_enrichment']);
+    }
+
+    public function test_thin_placeholder_match_picks_nearest_ledger_date_among_candidates(): void
+    {
+        $account = Account::factory()->create(['is_active' => true, 'current_balance' => 10000, 'opening_balance' => 10000]);
+        $expParent = Category::factory()->parent()->create(['code' => 'FOOD', 'is_active' => true]);
+        $expChild = Category::factory()->create(['parent_id' => $expParent->id, 'is_active' => true]);
+
+        $near = Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $expChild->id,
+            'transaction_type' => 'expense',
+            'amount' => 100,
+            'description' => 'Synced from external DB',
+            'transaction_date' => '2026-02-27',
+            'payment_method' => 'Bank Transfer',
+            'reference_number' => null,
+        ]);
+        Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $expChild->id,
+            'transaction_type' => 'expense',
+            'amount' => 100,
+            'description' => 'Synced from external DB',
+            'transaction_date' => '2026-03-05',
+            'payment_method' => 'Bank Transfer',
+            'reference_number' => null,
+        ]);
+
+        $svc = app(StatementReconciliationService::class);
+        $parsed = [
+            [
+                'date' => '2026-03-01',
+                'description' => 'UPI/600000000001/DR/ANY/YESB/foo',
+                'amount' => 100.0,
+                'type' => 'expense',
+                'statement_sequence' => 1,
+                'debit_amount' => 100.0,
+                'credit_amount' => 0.0,
+            ],
+        ];
+
+        $result = $svc->analyze($parsed, $account->id);
+
+        $this->assertSame('matched_needs_enrichment', $result['transactions'][0]['reconcile_status']);
+        $this->assertSame($near->id, $result['transactions'][0]['existing_transaction_id']);
+        $this->assertContains('existing_description_thin', $result['transactions'][0]['needs_detail_reasons']);
+        $this->assertContains('matched_by_amount_proximity', $result['transactions'][0]['needs_detail_reasons']);
+        $this->assertContains('statement_date_differs_from_ledger', $result['transactions'][0]['needs_detail_reasons']);
+    }
+
+    public function test_saved_bundle_links_multiple_statement_rows_to_one_ledger_txn(): void
+    {
+        $account = Account::factory()->create(['is_active' => true, 'current_balance' => 10000, 'opening_balance' => 10000]);
+        $expParent = Category::factory()->parent()->create(['code' => 'FOOD', 'is_active' => true]);
+        $expChild = Category::factory()->create(['parent_id' => $expParent->id, 'is_active' => true]);
+
+        $ledger = Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $expChild->id,
+            'transaction_type' => 'expense',
+            'amount' => 30,
+            'description' => 'Synced from external DB',
+            'transaction_date' => '2026-03-01',
+            'payment_method' => 'Bank Transfer',
+            'reference_number' => null,
+        ]);
+
+        $bundle = StatementLedgerBundle::create([
+            'account_id' => $account->id,
+            'ledger_transaction_id' => $ledger->id,
+        ]);
+        $bundle->rows()->create([
+            'statement_sequence' => 14,
+            'statement_date' => '2026-03-02',
+            'amount' => 20,
+            'description' => null,
+        ]);
+        $bundle->rows()->create([
+            'statement_sequence' => 15,
+            'statement_date' => '2026-03-03',
+            'amount' => 10,
+            'description' => null,
+        ]);
+
+        $svc = app(StatementReconciliationService::class);
+        $parsed = [
+            [
+                'statement_sequence' => 14,
+                'date' => '2026-03-02',
+                'description' => 'UPI/split-a',
+                'amount' => 20.0,
+                'type' => 'expense',
+                'debit_amount' => 20.0,
+                'credit_amount' => 0.0,
+            ],
+            [
+                'statement_sequence' => 15,
+                'date' => '2026-03-03',
+                'description' => 'UPI/split-b',
+                'amount' => 10.0,
+                'type' => 'expense',
+                'debit_amount' => 10.0,
+                'credit_amount' => 0.0,
+            ],
+        ];
+
+        $result = $svc->analyze($parsed, $account->id);
+
+        $this->assertTrue($result['transactions'][0]['matched_via_bundle']);
+        $this->assertTrue($result['transactions'][1]['matched_via_bundle']);
+        $this->assertSame($ledger->id, $result['transactions'][0]['existing_transaction_id']);
+        $this->assertSame($ledger->id, $result['transactions'][1]['existing_transaction_id']);
+        $this->assertSame((int) $bundle->id, $result['transactions'][0]['bundle_id']);
+        $this->assertContains('matched_via_split_bundle', $result['transactions'][0]['needs_detail_reasons']);
+        $this->assertContains('matched_via_split_bundle', $result['transactions'][1]['needs_detail_reasons']);
+    }
+
+    public function test_needs_detail_rows_include_reasons_and_are_logged(): void
+    {
+        $account = Account::factory()->create(['is_active' => true, 'current_balance' => 10000, 'opening_balance' => 10000]);
+        $expParent = Category::factory()->parent()->create(['code' => 'FOOD', 'is_active' => true]);
+        $expChild = Category::factory()->create(['parent_id' => $expParent->id, 'is_active' => true]);
+
+        $txn = Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $expChild->id,
+            'transaction_type' => 'expense',
+            'amount' => 624.29,
+            'description' => 'Synced from external DB',
+            'transaction_date' => '2026-03-22',
+            'payment_method' => 'Bank Transfer',
+            'reference_number' => null,
+        ]);
+
+        Log::spy();
+
+        $svc = app(StatementReconciliationService::class);
+        $parsed = [
+            [
+                'statement_sequence' => 2,
+                'date' => '2026-03-22',
+                'description' => 'DEMO CREDIT CARD PAYMENT/XXXXXXXXXXXX0000',
+                'amount' => 624.29,
+                'type' => 'expense',
+                'reference' => '2',
+                'debit_amount' => 624.29,
+                'credit_amount' => 0.0,
+            ],
+        ];
+
+        $result = $svc->analyze($parsed, $account->id);
+
+        $row = $result['transactions'][0];
+        $this->assertSame('matched_needs_enrichment', $row['reconcile_status']);
+        $this->assertSame($txn->id, $row['existing_transaction_id']);
+        $this->assertSame([
+            'existing_description_thin',
+            'matched_by_date_amount_bucket',
+        ], $row['needs_detail_reasons']);
+
+        Log::shouldHaveReceived('info')
+            ->once()
+            ->withArgs(fn (string $message, array $context): bool =>
+                $message === 'Statement reconciliation row needs detail'
+                && $context['row_index'] === 0
+                && $context['statement_sequence'] === 2
+                && $context['account_id'] === $account->id
+                && $context['statement_date'] === '2026-03-22'
+                && $context['ledger_transaction_date'] === '2026-03-22'
+                && $context['amount'] === 624.29
+                && $context['type'] === 'expense'
+                && $context['existing_transaction_id'] === $txn->id
+                && $context['reasons'] === ['existing_description_thin', 'matched_by_date_amount_bucket']
+                && $context['match_attempt_reason'] === 'matched_thin_date_bucket'
+            );
+    }
+
+    public function test_bundle_link_route_creates_bundle_and_redirects(): void
+    {
+        $account = Account::factory()->create(['is_active' => true, 'current_balance' => 10000, 'opening_balance' => 10000]);
+        $expParent = Category::factory()->parent()->create(['code' => 'FOOD', 'is_active' => true]);
+        $expChild = Category::factory()->create(['parent_id' => $expParent->id, 'is_active' => true]);
+
+        $ledger = Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $expChild->id,
+            'transaction_type' => 'expense',
+            'amount' => 30,
+            'description' => 'Synced from external DB',
+            'transaction_date' => '2026-03-01',
+            'payment_method' => 'Bank Transfer',
+            'reference_number' => null,
+        ]);
+
+        $this->post('/statements/bundle-link', [
+            'account_id' => $account->id,
+            'ledger_transaction_id' => $ledger->id,
+            'rows' => [
+                [
+                    'statement_sequence' => 14,
+                    'date' => '2026-03-02',
+                    'amount' => 20,
+                    'type' => 'expense',
+                    'description' => 'a',
+                ],
+                [
+                    'statement_sequence' => 15,
+                    'date' => '2026-03-03',
+                    'amount' => 10,
+                    'type' => 'expense',
+                    'description' => 'b',
+                ],
+            ],
+        ])->assertRedirect(route('statements.upload'));
+
+        $this->assertDatabaseCount('statement_ledger_bundles', 1);
+        $this->assertDatabaseCount('statement_ledger_bundle_rows', 2);
+    }
+
+    public function test_bundle_link_route_refreshes_existing_review_snapshot(): void
+    {
+        $account = Account::factory()->create(['is_active' => true, 'current_balance' => 10000, 'opening_balance' => 10000]);
+        $expParent = Category::factory()->parent()->create(['code' => 'FOOD', 'is_active' => true]);
+        $expChild = Category::factory()->create(['parent_id' => $expParent->id, 'is_active' => true]);
+
+        $ledger = Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $expChild->id,
+            'transaction_type' => 'expense',
+            'amount' => 30,
+            'description' => 'Synced from external DB',
+            'transaction_date' => '2026-03-01',
+            'payment_method' => 'Bank Transfer',
+            'reference_number' => null,
+        ]);
+
+        $parsed = [
+            [
+                'statement_sequence' => 14,
+                'date' => '2026-03-02',
+                'description' => 'UPI/split-a',
+                'amount' => 20.0,
+                'type' => 'expense',
+                'debit_amount' => 20.0,
+                'credit_amount' => 0.0,
+                'reconcile_status' => 'missing_in_db',
+            ],
+            [
+                'statement_sequence' => 15,
+                'date' => '2026-03-03',
+                'description' => 'UPI/split-b',
+                'amount' => 10.0,
+                'type' => 'expense',
+                'debit_amount' => 10.0,
+                'credit_amount' => 0.0,
+                'reconcile_status' => 'missing_in_db',
+            ],
+        ];
+
+        $response = $this->withSession([
+            'statement_review_snapshot' => [
+                'parsedData' => [
+                    'account_info' => [],
+                    'transactions' => $parsed,
+                ],
+                'reconcilePeriod' => ['start' => '2026-03-02', 'end' => '2026-03-03'],
+                'reconcileSummary' => [
+                    'missing_in_db' => 2,
+                    'matched_complete' => 0,
+                    'matched_needs_enrichment' => 0,
+                ],
+                'reconcileDebug' => false,
+                'suggestedAccount' => $account->only(['id', 'name', 'account_number', 'bank_name']),
+                'accountMatch' => 'full_number',
+                'accountMatchNote' => null,
+                'suggested_account_id' => $account->id,
+            ],
+        ])->post('/statements/bundle-link', [
+            'account_id' => $account->id,
+            'ledger_transaction_id' => $ledger->id,
+            'rows' => [
+                [
+                    'statement_sequence' => 14,
+                    'date' => '2026-03-02',
+                    'amount' => 20,
+                    'type' => 'expense',
+                    'description' => 'UPI/split-a',
+                ],
+                [
+                    'statement_sequence' => 15,
+                    'date' => '2026-03-03',
+                    'amount' => 10,
+                    'type' => 'expense',
+                    'description' => 'UPI/split-b',
+                ],
+            ],
+        ]);
+
+        $response->assertRedirect(route('statements.review'));
+        $response->assertSessionHas('success', 'Split rows linked to the ledger transaction and reconciliation refreshed.');
+
+        $snapshot = session('statement_review_snapshot');
+        $this->assertSame(0, $snapshot['reconcileSummary']['missing_in_db']);
+        $this->assertSame(2, $snapshot['reconcileSummary']['matched_needs_enrichment']);
+        $this->assertTrue($snapshot['parsedData']['transactions'][0]['matched_via_bundle']);
+        $this->assertTrue($snapshot['parsedData']['transactions'][1]['matched_via_bundle']);
+    }
+
+    public function test_reconcile_debug_adds_match_attempt_reason_when_enabled(): void
+    {
+        $account = Account::factory()->create(['is_active' => true, 'current_balance' => 10000, 'opening_balance' => 10000]);
+        Config::set('statement.reconcile_debug', true);
+
+        try {
+            $svc = app(StatementReconciliationService::class);
+            $parsed = [
+                [
+                    'date' => '2026-03-01',
+                    'description' => 'NOWHERE IN DB ROW',
+                    'amount' => 99.99,
+                    'type' => 'expense',
+                    'debit_amount' => 99.99,
+                    'credit_amount' => 0.0,
+                ],
+            ];
+            $result = $svc->analyze($parsed, $account->id);
+            $this->assertArrayHasKey('match_attempt_reason', $result['transactions'][0]);
+        } finally {
+            Config::set('statement.reconcile_debug', false);
+        }
+    }
+}

--- a/tests/Unit/StatementMatchKeyServiceTest.php
+++ b/tests/Unit/StatementMatchKeyServiceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\StatementMatchKeyService;
+use PHPUnit\Framework\TestCase;
+
+class StatementMatchKeyServiceTest extends TestCase
+{
+    private StatementMatchKeyService $svc;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->svc = new StatementMatchKeyService;
+    }
+
+    public function test_normalize_description_prefers_upi_segment(): void
+    {
+        $d = 'UPI/600208969804/DR/INDI/UTIB/foo';
+        $this->assertSame('upi/600208969804', $this->svc->normalizeDescription($d));
+    }
+
+    public function test_normalize_description_alphanumeric_prefix_without_upi(): void
+    {
+        $d = 'NEFT SOME BANK PAYMENT REF ABC';
+        $norm = $this->svc->normalizeDescription($d);
+        $this->assertLessThanOrEqual(30, strlen($norm));
+        $this->assertSame('neftsomebankpaymentrefabc', $norm);
+    }
+
+    public function test_match_key_is_deterministic(): void
+    {
+        $desc = 'DEMO CREDIT CARD PAYMENT/XXXXXXXXXXXX0000';
+        $expected = '2026-03-22_'.$this->svc->formatAmountForKey(624.29).'_'.$this->svc->normalizeDescription($desc);
+        $this->assertSame($expected, $this->svc->matchKey('2026-03-22', 624.29, $desc));
+    }
+
+    public function test_amount_norm_description_secondary_key_ignores_calendar_date(): void
+    {
+        $desc = 'UPI/111111111111/TEST SECONDARY KEY';
+        $expected = $this->svc->formatAmountForKey(100).'_'.$this->svc->normalizeDescription($desc);
+        $this->assertSame($expected, $this->svc->matchKeyAmountNormDesc(100, $desc));
+    }
+
+    public function test_is_description_thin_detects_placeholder_and_short(): void
+    {
+        $this->assertTrue($this->svc->isDescriptionThin(''));
+        $this->assertTrue($this->svc->isDescriptionThin('ab'));
+        $this->assertTrue($this->svc->isDescriptionThin('Synced from external DB'));
+        $this->assertFalse($this->svc->isDescriptionThin('Real narration here'));
+    }
+}

--- a/tests/Unit/StatementReconciliationServiceTest.php
+++ b/tests/Unit/StatementReconciliationServiceTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\StatementMatchKeyService;
+use App\Services\StatementReconciliationService;
+use Tests\TestCase;
+
+class StatementReconciliationServiceTest extends TestCase
+{
+    public function test_balance_chain_detects_break(): void
+    {
+        $svc = new StatementReconciliationService(new StatementMatchKeyService);
+
+        $parsed = [
+            [
+                'date' => '2026-03-22',
+                'description' => 'A',
+                'amount' => 23250.0,
+                'type' => 'income',
+                'reference' => '1',
+                'balance_after' => 252758.24,
+                'statement_sequence' => 1,
+                'debit_amount' => 0.0,
+                'credit_amount' => 23250.0,
+            ],
+            [
+                'date' => '2026-03-22',
+                'description' => 'B',
+                'amount' => 624.29,
+                'type' => 'expense',
+                'reference' => '2',
+                'balance_after' => 252000.00,
+                'statement_sequence' => 2,
+                'debit_amount' => 624.29,
+                'credit_amount' => 0.0,
+            ],
+        ];
+
+        $result = $svc->analyze($parsed, null);
+
+        $this->assertFalse($result['summary']['balance']['chain_ok']);
+        $this->assertSame(2, $result['summary']['balance']['broken_at_statement_sequence']);
+    }
+
+    public function test_derived_period_from_transactions(): void
+    {
+        $svc = new StatementReconciliationService(new StatementMatchKeyService);
+
+        $parsed = [
+            [
+                'date' => '2026-03-01',
+                'description' => 'x',
+                'amount' => 10,
+                'type' => 'expense',
+                'debit_amount' => 10,
+                'credit_amount' => 0,
+            ],
+            [
+                'date' => '2026-03-31',
+                'description' => 'y',
+                'amount' => 5,
+                'type' => 'income',
+                'debit_amount' => 0,
+                'credit_amount' => 5,
+            ],
+        ];
+
+        $result = $svc->analyze($parsed, null);
+
+        $this->assertSame('2026-03-01', $result['period']['start']);
+        $this->assertSame('2026-03-31', $result['period']['end']);
+    }
+}

--- a/tests/fixtures/statement_demo_broken_balance.csv
+++ b/tests/fixtures/statement_demo_broken_balance.csv
@@ -1,0 +1,11 @@
+Name,DEMO STATEMENT USER
+Account Number,100036608561
+IFSC,TEST0001234
+Account Type,Savings
+Transaction From,Mar 2026
+
+Transaction List
+
+Sr.No.,Date,Type, Description, Debit ,Credit ,Balance
+1,Mar 22  2026,Transfer Credit,UPI/900000000001/CR/DEMO/TEST/demo@okbank/Mar,-,23250.00,252758.24
+2,Mar 22  2026,Transfer Debit,DEMO CREDIT CARD PAYMENT/XXXXXXXXXXXX0000,624.29,-,252000.00

--- a/tests/fixtures/statement_demo_sample.csv
+++ b/tests/fixtures/statement_demo_sample.csv
@@ -1,0 +1,11 @@
+Name,DEMO STATEMENT USER
+Account Number,100036608561
+IFSC,TEST0001234
+Account Type,Savings
+Transaction From,Mar 2026
+
+Transaction List
+
+Sr.No.,Date,Type, Description, Debit ,Credit ,Balance
+1,Mar 22  2026,Transfer Credit,UPI/900000000001/CR/DEMO/TEST/demo@okbank/Mar,-,23250.00,252758.24
+2,Mar 22  2026,Transfer Debit,DEMO CREDIT CARD PAYMENT/XXXXXXXXXXXX0000,624.29,-,252133.95


### PR DESCRIPTION
## Summary

Refs #36.

Stabilizes the statement import review lane with session-backed review, reconciliation status, audit-friendly balance checks, deterministic fixture parsing, duplicate validation, enrichment, and split-bundle linking.

## What changed

- Adds statement review persistence and `/statements/review`, `/statements/enrich`, and `/statements/bundle-link` flows.
- Adds reconciliation services for match keys, missing/in-ledger/needs-detail status, date drift, thin descriptions, split bundles, and statement-vs-ledger net delta.
- Expands statement parser output with balances, debit/credit amounts, sequence ordering, and preamble-first account metadata to avoid slow LLM calls when headers are available.
- Updates review UI with month tabs, status badges, balance mismatch detail, needs-detail save action, split-bundle linking, and import duplicate feedback.
- Adds demo fixtures and focused feature/unit coverage for import, parser, reconciliation, bundle links, and auditability.

## Validation

- `php artisan test tests/Feature/AiCategorizeTest.php tests/Feature/StatementContentSplitterTest.php tests/Feature/StatementImportTest.php tests/Feature/StatementParserServiceTest.php tests/Feature/StatementReconcileTest.php tests/Unit/StatementMatchKeyServiceTest.php tests/Unit/StatementReconciliationServiceTest.php` -> 41 passed, 223 assertions.
- `npm run build` -> passed; Vite still reports the existing large chunk warning.
- Manual browser QA on `http://expense.com/statements/upload` and review flow with demo fixtures, including broken-balance audit display.