### PR TITLE
Sync/Data Integrity: Harden fresh sync and dedupe safety

### DIFF
--- a/app/Console/Commands/DedupeTransactionsByDescriptionCommand.php
+++ b/app/Console/Commands/DedupeTransactionsByDescriptionCommand.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Transaction;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class DedupeTransactionsByDescriptionCommand extends Command
+{
+    protected $signature = 'transactions:dedupe-by-description
+                            {--dry-run : Show what would be deleted without deleting}
+                            {--force : Delete without the interactive confirmation prompt}
+                            {--keep=oldest : Keep oldest (lowest id) or newest per duplicate group}';
+
+    protected $description = 'Delete duplicate transactions only when account, date, type, amount, and trimmed description all match';
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $force = (bool) $this->option('force');
+        $keep = strtolower((string) $this->option('keep'));
+        if (! in_array($keep, ['oldest', 'newest'], true)) {
+            $this->error('Option --keep must be oldest or newest.');
+
+            return Command::FAILURE;
+        }
+        $groups = $this->duplicateGroups($keep);
+        if ($groups->isEmpty()) {
+            $this->info('No duplicate transaction groups found.');
+
+            return Command::SUCCESS;
+        }
+        $totalDelete = $groups->sum(fn (array $group) => $group['delete_ids']->count());
+        $this->displayPreview($groups, $totalDelete);
+        if ($dryRun) {
+            $this->warn("[dry-run] Would delete {$totalDelete} duplicate row(s). Run without --dry-run and confirm, or pass --force, to apply.");
+
+            return Command::SUCCESS;
+        }
+        if (! $force && ! $this->confirm("Delete {$totalDelete} duplicate transaction(s) using model deletes?")) {
+            $this->info('Dedupe cancelled before deleting any transactions.');
+
+            return Command::SUCCESS;
+        }
+        $deleted = 0;
+        foreach ($groups as $group) {
+            $transactions = Transaction::query()
+                ->whereIn('id', $group['delete_ids']->all())
+                ->orderBy('id')
+                ->get();
+            foreach ($transactions as $transaction) {
+                if ($transaction->delete()) {
+                    $deleted++;
+                }
+            }
+        }
+        $this->info("Deleted {$deleted} duplicate transaction(s). Account balances were updated via model events.");
+
+        return Command::SUCCESS;
+    }
+
+    private function duplicateGroups(string $keep)
+    {
+        $trimExpr = $this->trimmedDescriptionExpression();
+
+        return DB::table('transactions')
+            ->whereNotNull('description')
+            ->whereRaw("{$trimExpr} != ".$this->emptySqlLiteral())
+            ->selectRaw("account_id, transaction_date, transaction_type, amount, {$trimExpr} as desc_key, COUNT(*) as row_count")
+            ->groupBy('account_id', 'transaction_date', 'transaction_type', 'amount', DB::raw($trimExpr))
+            ->havingRaw('COUNT(*) > 1')
+            ->orderBy('account_id')
+            ->orderBy('transaction_date')
+            ->orderBy('transaction_type')
+            ->orderBy('amount')
+            ->get()
+            ->map(function (object $row) use ($keep, $trimExpr) {
+                $ids = DB::table('transactions')
+                    ->where('account_id', $row->account_id)
+                    ->where('transaction_date', $row->transaction_date)
+                    ->where('transaction_type', $row->transaction_type)
+                    ->where('amount', $row->amount)
+                    ->whereRaw("{$trimExpr} = ?", [$row->desc_key])
+                    ->orderBy('id')
+                    ->pluck('id')
+                    ->values();
+                if ($ids->count() < 2) {
+                    return null;
+                }
+                $keepId = $keep === 'oldest' ? $ids->first() : $ids->last();
+                $deleteIds = $ids->reject(fn (int $id) => $id === $keepId)->values();
+
+                return [
+                    'account_id' => $row->account_id,
+                    'transaction_date' => $row->transaction_date,
+                    'transaction_type' => $row->transaction_type,
+                    'amount' => $row->amount,
+                    'description' => $row->desc_key,
+                    'ids' => $ids,
+                    'keep_id' => $keepId,
+                    'delete_ids' => $deleteIds,
+                ];
+            })
+            ->filter()
+            ->values();
+    }
+
+    private function displayPreview($groups, int $totalDelete): void
+    {
+        $this->warn("Duplicate preview: {$groups->count()} group(s), {$totalDelete} transaction(s) marked for deletion.");
+        $this->line('Affected transaction IDs: '.$groups->flatMap(fn (array $group) => $group['delete_ids'])->implode(', '));
+        $this->table(
+            ['Account', 'Date', 'Type', 'Amount', 'Description', 'Keep ID', 'Delete IDs'],
+            $groups->take(25)->map(fn (array $group) => [
+                $group['account_id'],
+                $group['transaction_date'],
+                $group['transaction_type'],
+                $group['amount'],
+                str($group['description'])->limit(50)->toString(),
+                $group['keep_id'],
+                $group['delete_ids']->implode(', '),
+            ])->all()
+        );
+        if ($groups->count() > 25) {
+            $this->line('Preview limited to first 25 groups; full affected ID list is shown above.');
+        }
+    }
+
+    private function trimmedDescriptionExpression(): string
+    {
+        return match (DB::getDriverName()) {
+            'mysql', 'mariadb' => 'TRIM(IFNULL(description, '.$this->emptySqlLiteral().'))',
+            default => 'TRIM(COALESCE(description, '.$this->emptySqlLiteral().'))',
+        };
+    }
+
+    private function emptySqlLiteral(): string
+    {
+        return chr(39).chr(39);
+    }
+}

--- a/app/Console/Commands/SyncExpenseData.php
+++ b/app/Console/Commands/SyncExpenseData.php
@@ -2,9 +2,11 @@
 
 namespace App\Console\Commands;
 
+use App\Models\Transaction;
 use App\Services\ExpenseSyncService;
-use Illuminate\Console\Command;
 use Exception;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 
 class SyncExpenseData extends Command
 {
@@ -16,7 +18,8 @@ class SyncExpenseData extends Command
     protected $signature = 'expense:sync
                           {--dry-run : Run without making changes to the database}
                           {--db-path= : Path to external database file}
-                          {--force : Skip confirmation prompt}';
+                          {--force : Skip confirmation prompt}
+                          {--fresh : Preview and delete transactions previously synced from external DB (reference_number EXT_*) before syncing}';
 
     /**
      * The console command description.
@@ -33,24 +36,46 @@ class SyncExpenseData extends Command
         $dryRun = $this->option('dry-run');
         $dbPath = $this->option('db-path');
         $force = $this->option('force');
+        $fresh = $this->option('fresh');
 
         $this->info('🚀 Starting Expense Data Sync');
         $this->newLine();
 
         // Show configuration
-        $this->displayConfiguration($dbPath, $dryRun);
+        $this->displayConfiguration($dbPath, $dryRun, $fresh);
 
-        // Confirmation prompt (unless force is used)
-        if (!$force && !$dryRun) {
-            if (!$this->confirm('Do you want to proceed with the sync?')) {
+        $freshTransactions = collect();
+
+        if ($fresh) {
+            $freshTransactions = $this->freshSyncTransactions();
+            $this->displayFreshPreview($freshTransactions);
+        }
+
+        if ($fresh && ! $dryRun && $freshTransactions->isNotEmpty() && ! $force) {
+            if (! $this->confirm("Delete {$freshTransactions->count()} EXT_* transaction(s) using model deletes, then continue sync?")) {
+                $this->info('Fresh sync cancelled before deleting any transactions.');
+
+                return Command::SUCCESS;
+            }
+        }
+
+        if (! $fresh && ! $force && ! $dryRun) {
+            if (! $this->confirm('Do you want to proceed with the sync?')) {
                 $this->info('Sync cancelled.');
+
                 return Command::SUCCESS;
             }
         }
 
         try {
+            if ($fresh && ! $dryRun) {
+                DB::beginTransaction();
+                $deleted = $this->deleteFreshTransactions($freshTransactions);
+                $this->info("Removed {$deleted} previously synced transaction(s) (reference EXT_*) via model deletes.");
+                $this->newLine();
+            }
             // Initialize sync service
-            $syncService = new ExpenseSyncService($dbPath);
+            $syncService = $this->makeSyncService($dbPath);
 
             // Create progress bar
             $this->info('Initializing sync process...');
@@ -61,19 +86,80 @@ class SyncExpenseData extends Command
             // Display results
             $this->displayResults($stats, $dryRun);
 
+            if ($fresh && ! $dryRun) {
+                DB::commit();
+            }
+
             return Command::SUCCESS;
 
         } catch (Exception $e) {
-            $this->error('❌ Sync failed: ' . $e->getMessage());
-            $this->error('Stack trace: ' . $e->getTraceAsString());
+            if ($fresh && ! $dryRun && DB::transactionLevel() > 0) {
+                DB::rollBack();
+            }
+            $this->error('❌ Sync failed: '.$e->getMessage());
+            $this->error('Stack trace: '.$e->getTraceAsString());
+
             return Command::FAILURE;
         }
+    }
+
+    protected function makeSyncService(?string $dbPath): ExpenseSyncService
+    {
+        return new ExpenseSyncService($dbPath);
+    }
+
+    private function freshSyncTransactions()
+    {
+        return Transaction::query()
+            ->where('reference_number', 'like', 'EXT_%')
+            ->orderBy('id')
+            ->get(['id', 'account_id', 'transaction_date', 'transaction_type', 'amount', 'reference_number', 'description']);
+    }
+
+    private function displayFreshPreview($transactions): void
+    {
+        $count = $transactions->count();
+        if ($count === 0) {
+            $this->info('Fresh sync preview: no EXT_* transactions found for deletion.');
+            $this->newLine();
+
+            return;
+        }
+        $this->warn("Fresh sync preview: {$count} EXT_* transaction(s) will be deleted before syncing.");
+        $this->line('Affected transaction IDs: '.$transactions->pluck('id')->implode(', '));
+        $this->table(
+            ['ID', 'Date', 'Type', 'Amount', 'Reference', 'Description'],
+            $transactions->take(25)->map(fn (Transaction $transaction) => [
+                $transaction->id,
+                optional($transaction->transaction_date)->toDateString(),
+                $transaction->transaction_type,
+                $transaction->amount,
+                $transaction->reference_number,
+                str($transaction->description)->limit(60)->toString(),
+            ])->all()
+        );
+        if ($count > 25) {
+            $this->line('Preview limited to first 25 rows; full affected ID list is shown above.');
+        }
+        $this->newLine();
+    }
+
+    private function deleteFreshTransactions($transactions): int
+    {
+        $deleted = 0;
+        foreach ($transactions as $transaction) {
+            if ($transaction->delete()) {
+                $deleted++;
+            }
+        }
+
+        return $deleted;
     }
 
     /**
      * Display configuration information
      */
-    private function displayConfiguration(?string $dbPath, bool $dryRun): void
+    private function displayConfiguration(?string $dbPath, bool $dryRun, bool $fresh = false): void
     {
         $actualDbPath = $dbPath ?: config('sync.external_db_path');
 
@@ -84,6 +170,7 @@ class SyncExpenseData extends Command
                 ['External DB Path', $actualDbPath],
                 ['File Exists', file_exists($actualDbPath) ? '✅ Yes' : '❌ No'],
                 ['Mode', $dryRun ? '🔍 Dry Run (no changes)' : '💾 Live Sync'],
+                ['Fresh (purge EXT_*)', $fresh ? 'Yes' : 'No'],
                 ['Skip Duplicates', config('sync.sync_options.skip_duplicates') ? 'Yes' : 'No'],
                 ['Batch Size', config('sync.sync_options.batch_size')],
             ]

--- a/tests/Feature/DedupeTransactionsByDescriptionCommandTest.php
+++ b/tests/Feature/DedupeTransactionsByDescriptionCommandTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\Transaction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DedupeTransactionsByDescriptionCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_removes_duplicates_keeping_oldest(): void
+    {
+        $parent = Category::factory()->parent()->create(['is_active' => true]);
+        $child = Category::factory()->create(['parent_id' => $parent->id, 'is_active' => true]);
+        $account = Account::factory()->create(['is_active' => true]);
+
+        $txn1 = Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $child->id,
+            'transaction_type' => 'expense',
+            'amount' => 10,
+            'description' => '  TXN-123  ',
+            'transaction_date' => '2026-01-10',
+            'payment_method' => 'Bank Transfer',
+        ]);
+        Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $child->id,
+            'transaction_type' => 'expense',
+            'amount' => 10,
+            'description' => 'TXN-123',
+            'transaction_date' => '2026-01-10',
+            'payment_method' => 'Bank Transfer',
+        ]);
+        Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $child->id,
+            'transaction_type' => 'expense',
+            'amount' => 100,
+            'description' => 'other',
+            'transaction_date' => '2026-03-10',
+            'payment_method' => 'Bank Transfer',
+        ]);
+
+        $this->artisan('transactions:dedupe-by-description', ['--force' => true])
+            ->assertSuccessful();
+
+        $this->assertSame(2, Transaction::query()->count());
+        $this->assertNotNull(Transaction::query()->find($txn1->id));
+        $this->assertSame('  TXN-123  ', Transaction::query()->find($txn1->id)?->description);
+    }
+
+    public function test_command_keeps_newest_when_option_set(): void
+    {
+        $parent = Category::factory()->parent()->create(['is_active' => true]);
+        $child = Category::factory()->create(['parent_id' => $parent->id, 'is_active' => true]);
+        $account = Account::factory()->create(['is_active' => true]);
+
+        Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $child->id,
+            'transaction_type' => 'expense',
+            'amount' => 2,
+            'description' => 'SAME',
+            'transaction_date' => '2026-01-02',
+            'payment_method' => 'Bank Transfer',
+        ]);
+        $latest = Transaction::create([
+            'account_id' => $account->id,
+            'category_id' => $child->id,
+            'transaction_type' => 'expense',
+            'amount' => 2,
+            'description' => 'SAME',
+            'transaction_date' => '2026-01-02',
+            'payment_method' => 'Bank Transfer',
+        ]);
+
+        $this->artisan('transactions:dedupe-by-description', ['--keep' => 'newest', '--force' => true])
+            ->assertSuccessful();
+
+        $this->assertSame(1, Transaction::query()->count());
+        $this->assertSame($latest->id, Transaction::query()->first()->id);
+    }
+
+    public function test_command_rejects_invalid_keep_option(): void
+    {
+        $this->artisan('transactions:dedupe-by-description', ['--keep' => 'middle'])
+            ->assertFailed();
+    }
+
+    public function test_command_does_not_delete_same_description_when_core_fields_differ(): void
+    {
+        $parent = Category::factory()->parent()->create(['is_active' => true]);
+        $child = Category::factory()->create(['parent_id' => $parent->id, 'is_active' => true]);
+        $account = Account::factory()->create(['is_active' => true]);
+        $otherAccount = Account::factory()->create(['is_active' => true]);
+        foreach ([['account' => $account->id, 'date' => '2026-01-10', 'type' => 'expense', 'amount' => 10], ['account' => $account->id, 'date' => '2026-01-10', 'type' => 'expense', 'amount' => 11], ['account' => $account->id, 'date' => '2026-01-11', 'type' => 'expense', 'amount' => 10], ['account' => $otherAccount->id, 'date' => '2026-01-10', 'type' => 'expense', 'amount' => 10], ['account' => $account->id, 'date' => '2026-01-10', 'type' => 'income', 'amount' => 10]] as $row) {
+            Transaction::create(['account_id' => $row['account'], 'category_id' => $child->id, 'transaction_type' => $row['type'], 'amount' => $row['amount'], 'description' => 'SAME-DESC', 'transaction_date' => $row['date'], 'payment_method' => 'Bank Transfer']);
+        }
+        $this->artisan('transactions:dedupe-by-description', ['--force' => true])->assertSuccessful();
+        $this->assertSame(5, Transaction::query()->count());
+    }
+
+    public function test_dry_run_does_not_delete_and_model_delete_reverses_balance(): void
+    {
+        $parent = Category::factory()->parent()->create(['is_active' => true]);
+        $child = Category::factory()->create(['parent_id' => $parent->id, 'is_active' => true]);
+        $account = Account::factory()->create(['opening_balance' => 100, 'current_balance' => 100, 'is_active' => true]);
+        foreach ([1, 2] as $index) {
+            Transaction::create(['account_id' => $account->id, 'category_id' => $child->id, 'transaction_type' => 'expense', 'amount' => 10, 'description' => 'BALANCE-DUPE', 'transaction_date' => '2026-01-10', 'payment_method' => 'Bank Transfer']);
+        }
+        $this->assertSame('80.00', $account->refresh()->current_balance);
+        $this->artisan('transactions:dedupe-by-description', ['--dry-run' => true])->assertSuccessful();
+        $this->assertSame(2, Transaction::query()->count());
+        $this->assertSame('80.00', $account->refresh()->current_balance);
+        $this->artisan('transactions:dedupe-by-description', ['--force' => true])->assertSuccessful();
+        $this->assertSame(1, Transaction::query()->count());
+        $this->assertSame('90.00', $account->refresh()->current_balance);
+    }
+}

--- a/tests/Feature/SyncExpenseDataCommandTest.php
+++ b/tests/Feature/SyncExpenseDataCommandTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Console\Commands\SyncExpenseData;
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Services\ExpenseSyncService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SyncExpenseDataCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function bindFakeSyncCommand(): void
+    {
+        $this->app->bind(SyncExpenseData::class, fn () => new class extends SyncExpenseData
+        {
+            protected function makeSyncService(?string $dbPath): ExpenseSyncService
+            {
+                return new class extends ExpenseSyncService
+                {
+                    public function __construct() {}
+
+                    public function sync(bool $dryRun = false): array
+                    {
+                        return ['categories_synced' => 0, 'accounts_synced' => 0, 'transactions_synced' => 0, 'errors' => 0];
+                    }
+                };
+            }
+        });
+    }
+
+    public function test_fresh_dry_run_previews_without_deleting_ext_transactions(): void
+    {
+        $this->bindFakeSyncCommand();
+        [$account] = $this->makeAccountWithExtTransaction('EXT_1', 10);
+        $this->assertSame('90.00', $account->refresh()->current_balance);
+        $this->artisan('expense:sync', ['--fresh' => true, '--dry-run' => true])->assertSuccessful();
+        $this->assertSame(1, Transaction::query()->where('reference_number', 'EXT_1')->count());
+        $this->assertSame('90.00', $account->refresh()->current_balance);
+    }
+
+    public function test_fresh_force_deletes_ext_transactions_with_model_balance_events(): void
+    {
+        $this->bindFakeSyncCommand();
+        [$account, $child] = $this->makeAccountWithExtTransaction('EXT_2', 10);
+        Transaction::create(['account_id' => $account->id, 'category_id' => $child->id, 'transaction_type' => 'expense', 'amount' => 7, 'description' => 'Manual', 'transaction_date' => '2026-01-11', 'payment_method' => 'Bank Transfer', 'reference_number' => 'MANUAL']);
+        $this->assertSame('83.00', $account->refresh()->current_balance);
+        $this->artisan('expense:sync', ['--fresh' => true, '--force' => true])->assertSuccessful();
+        $this->assertSame(0, Transaction::query()->where('reference_number', 'EXT_2')->count());
+        $this->assertSame(1, Transaction::query()->where('reference_number', 'MANUAL')->count());
+        $this->assertSame('93.00', $account->refresh()->current_balance);
+    }
+
+    private function makeAccountWithExtTransaction(string $referenceNumber, int $amount): array
+    {
+        $parent = Category::factory()->parent()->create(['is_active' => true]);
+        $child = Category::factory()->create(['parent_id' => $parent->id, 'is_active' => true]);
+        $account = Account::factory()->create(['opening_balance' => 100, 'current_balance' => 100, 'is_active' => true]);
+        Transaction::create(['account_id' => $account->id, 'category_id' => $child->id, 'transaction_type' => 'expense', 'amount' => $amount, 'description' => 'External', 'transaction_date' => '2026-01-10', 'payment_method' => 'Bank Transfer', 'reference_number' => $referenceNumber]);
+
+        return [$account, $child];
+    }
+}


### PR DESCRIPTION
## Summary
- Adds preview-first fresh sync cleanup for EXT_* transactions with affected IDs before mutation.
- Uses per-model deletes for fresh sync and dedupe so account balance events run.
- Adds stricter dedupe grouping by account, date, type, amount, and trimmed description.
- Covers dry-run, force execution, invalid options, false-positive prevention, and balance safety in feature tests.

Related to #50

## Verification
- vendor/bin/pint app/Console/Commands/SyncExpenseData.php app/Console/Commands/DedupeTransactionsByDescriptionCommand.php tests/Feature/DedupeTransactionsByDescriptionCommandTest.php tests/Feature/SyncExpenseDataCommandTest.php
- /usr/bin/php artisan test tests/Feature/DedupeTransactionsByDescriptionCommandTest.php tests/Feature/SyncExpenseDataCommandTest.php
- git diff --check

## Manual review ask
Please review the fresh sync preview/delete flow and dedupe matching safety before merge.