### PR TITLE
Clean local WIP before category mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,19 @@ database/database.sqlite
 database/expense_manager.db
 *.db:Zone.Identifier
 
+# Python (scripts: smart import, anomaly reconciliation)
+/scripts/.venv/
+/scripts/anomaly.py
+/scripts/requirements.txt
+**/__pycache__/
+*.py[cod]
+
+# Local assistant/runtime context
+AGENTS.md
+.hermes/
+.codex/
+.claude/
+
 # Backup files
 *.backup
 *.bak

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -37,7 +37,10 @@ class HandleInertiaRequests extends Middleware
     {
         return [
             ...parent::share($request),
-            //
+            'flash' => [
+                'success' => fn () => $request->session()->get('success'),
+                'warning' => fn () => $request->session()->get('warning'),
+            ],
         ];
     }
 }

--- a/resources/js/Pages/Accounts/Edit.jsx
+++ b/resources/js/Pages/Accounts/Edit.jsx
@@ -11,9 +11,12 @@ export default function Edit({ account, accountTypes }) {
         bank_name: account.bank_name || '',
         account_number: account.account_number || '',
         ifsc_code: account.ifsc_code || '',
-        opening_balance: account.opening_balance || '0.00',
-        current_balance: account.current_balance || '0.00',
-        credit_limit: account.credit_limit || '0.00',
+        opening_balance:
+            account.opening_balance != null && account.opening_balance !== '' ? String(account.opening_balance) : '0.00',
+        current_balance:
+            account.current_balance != null && account.current_balance !== '' ? String(account.current_balance) : '0.00',
+        credit_limit:
+            account.credit_limit != null && account.credit_limit !== '' ? String(account.credit_limit) : '0.00',
         is_active: account.is_active ?? true,
     });
 

--- a/resources/js/utils/inputValidation.js
+++ b/resources/js/utils/inputValidation.js
@@ -226,9 +226,10 @@ export const validateTags = (tags, maxTags = 10, maxTagLength = 30) => {
 };
 
 /**
- * Real-time amount input handler
+ * Real-time amount input handler.
+ * Either: handleAmountInput(e, (value) => { ... })  OR  handleAmountInput(e, setData, 'fieldKey') for useForm.setData.
  */
-export const handleAmountInput = (event, setValue) => {
+export const handleAmountInput = (event, setter, fieldKey = undefined) => {
     let value = event.target.value;
 
     value = value.replace(/[^\d.-]/g, '');
@@ -246,7 +247,11 @@ export const handleAmountInput = (event, setValue) => {
         value = value.replace(/-/g, '');
     }
 
-    setValue(value);
+    if (typeof fieldKey === 'string') {
+        setter(fieldKey, value);
+    } else {
+        setter(value);
+    }
 };
 
 /**


### PR DESCRIPTION
## Summary
- Quarantines local-only anomaly research scripts and assistant/runtime context through .gitignore.
- Shares Inertia flash success/warning props used by the statement review flow.
- Preserves zero-value account balances when editing accounts.
- Lets amount input helpers support both callback setters and Inertia useForm setData(field, value).

## Verification
- vendor/bin/pint app/Http/Middleware/HandleInertiaRequests.php
- php artisan test tests/Feature/StatementReconcileTest.php
- npm run build
- git diff --check

## Notes
- Local scripts/anomaly.py and scripts/requirements.txt remain local-only and are not committed.
- This is the COD-51 cleanup checkpoint before COD-43 category mapping work.
