### PR TITLE
Harden category mapping type filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,19 @@ database/database.sqlite
 database/expense_manager.db
 *.db:Zone.Identifier
 
+# Python (scripts: smart import, anomaly reconciliation)
+/scripts/.venv/
+/scripts/anomaly.py
+/scripts/requirements.txt
+**/__pycache__/
+*.py[cod]
+
+# Local assistant/runtime context
+AGENTS.md
+.hermes/
+.codex/
+.claude/
+
 # Backup files
 *.backup
 *.bak

--- a/app/AI/Tools/ListCategoriesTool.php
+++ b/app/AI/Tools/ListCategoriesTool.php
@@ -7,7 +7,7 @@ use Prism\Prism\Tool;
 
 class ListCategoriesTool extends Tool
 {
-public function __construct()
+    public function __construct()
     {
         $this
             ->as('list_categories')
@@ -16,17 +16,17 @@ public function __construct()
             ->using($this->execute(...));
     }
 
-public function execute(?string $type = null): string
+    public function execute(?string $type = null): string
     {
         try {
-            $query = Category::with(['parent', 'activeChildren' => fn($q) => $q->active()->withCount('transactions')])
+            $query = Category::with(['parent', 'activeChildren' => fn ($q) => $q->active()->withCount('transactions')])
                 ->active()
                 ->parent();
 
             if ($type === 'income') {
-                $query->where('code', 'INCOME');
+                $query->incomeRoot();
             } elseif ($type === 'expense') {
-                $query->whereNotIn('code', ['INCOME', 'ACCOUNTTR']);
+                $query->expenseParent();
             }
 
             $parents = $query->orderBy('name')->get()
@@ -52,7 +52,7 @@ public function execute(?string $type = null): string
         } catch (\Throwable $e) {
             return json_encode([
                 'success' => false,
-                'error' => 'Failed to fetch categories: ' . $e->getMessage(),
+                'error' => 'Failed to fetch categories: '.$e->getMessage(),
             ]);
         }
     }

--- a/app/Http/Controllers/AiController.php
+++ b/app/Http/Controllers/AiController.php
@@ -2,15 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\AI\Tools\ListCategoriesTool;
 use App\Models\Category;
+use App\Services\LlmLoggingService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Prism\Prism\Facades\Prism;
-use App\Services\LlmLoggingService;
-use App\AI\Tools\ListCategoriesTool;
 use Prism\Prism\Streaming\Events\TextDeltaEvent;
-use Prism\Prism\Streaming\Events\ToolCallEvent;
 use Prism\Prism\Streaming\Events\ToolResultEvent;
 use Prism\Prism\ValueObjects\ToolResult;
 
@@ -29,7 +28,7 @@ class AiController extends Controller
         ]);
 
         $logger = app(LlmLoggingService::class);
-        $sessionId = 'cat_' . uniqid();
+        $sessionId = 'cat_'.uniqid();
 
         $provider = config('ai.provider');
         $model = config('ai.categorize_model') ?: config('ai.model');
@@ -42,16 +41,17 @@ class AiController extends Controller
 
         // Check if categories exist for this type (quick DB check)
         $hasCategories = Category::active()->parent()
-            ->when($type === 'income', fn($q) => $q->where('code', 'INCOME'))
-            ->when($type === 'expense', fn($q) => $q->whereNotIn('code', ['INCOME', 'ACCOUNTTR']))
+            ->when($type === 'income', fn ($q) => $q->incomeRoot())
+            ->when($type === 'expense', fn ($q) => $q->expenseParent())
             ->exists();
 
         if (! $hasCategories) {
             $message = $type === 'income' ? 'No income categories configured' : 'No expense categories configured';
+
             return response()->json(['error' => $message], 422);
         }
         $userPrompt = $this->buildCategorizePrompt($validated['description'], $type);
-        $logger->logMessages($sessionId, [], "Tool-enabled categorize: type={$type}"); 
+        $logger->logMessages($sessionId, [], "Tool-enabled categorize: type={$type}");
 
         try {
             $start = microtime(true);
@@ -59,7 +59,7 @@ class AiController extends Controller
                 ->using($provider, $model)
                 ->withSystemPrompt('You are a financial categorization expert. You MUST call the list_categories tool with type='.$type.' first, read tree_structure names and ids, then output valid JSON only (no markdown) with matched category_id and subcategory_id from that tree.')
                 ->withPrompt($userPrompt)
-                ->withTools([new ListCategoriesTool()])
+                ->withTools([new ListCategoriesTool])
                 ->withMaxSteps(max(2, $categorizeMaxSteps))
                 ->withMaxTokens($maxTokens)
                 ->asText();
@@ -69,11 +69,11 @@ class AiController extends Controller
             $duration = round((microtime(true) - $start) * 1000);
             $logger->logResponse($sessionId, $duration, ['raw_text_length' => strlen($finalText)]);
 
-            $logger->logMessages($sessionId, [], 'Raw LLM response: ' . substr($finalText, 0, 1000));
+            $logger->logMessages($sessionId, [], 'Raw LLM response: '.substr($finalText, 0, 1000));
 
             $data = $this->decodeJsonResponse($finalText);
 
-            $logger->logMessages($sessionId, [], 'Parsed data: ' . json_encode($data));
+            $logger->logMessages($sessionId, [], 'Parsed data: '.json_encode($data));
 
             $normalized = null;
             $matchedDescriptionToTree = false;
@@ -97,7 +97,7 @@ class AiController extends Controller
                     if ($fromHeuristic) {
                         $normalized = $fromHeuristic;
                         $matchedDescriptionToTree = true;
-                        $logger->logMessages($sessionId, [], 'Description-to-tree heuristic: ' . json_encode($normalized));
+                        $logger->logMessages($sessionId, [], 'Description-to-tree heuristic: '.json_encode($normalized));
                     }
                 }
             }
@@ -110,10 +110,11 @@ class AiController extends Controller
                 $normalized = $this->refineExpenseSiblingByDescription($validated['description'], $normalized);
             }
 
-            $logger->logMessages($sessionId, [], 'Normalized: ' . json_encode($normalized));
+            $logger->logMessages($sessionId, [], 'Normalized: '.json_encode($normalized));
 
             if (! $normalized) {
                 $logger->logError($sessionId, 'normalize_failed', new \Exception('Invalid category IDs'));
+
                 return response()->json(['error' => 'AI returned invalid category ids'], 422);
             }
 
@@ -142,19 +143,21 @@ class AiController extends Controller
                 ];
             }
 
-            $logger->logMessages($sessionId, [], 'SUCCESS: ' . json_encode($successPayload));
+            $logger->logMessages($sessionId, [], 'SUCCESS: '.json_encode($successPayload));
 
             return response()->json($successPayload);
 
         } catch (\Throwable $e) {
             $logger->logError($sessionId, 'prism_failed', $e);
-            return response()->json(['error' => 'AI categorization failed: ' . $e->getMessage()], 503);
+
+            return response()->json(['error' => 'AI categorization failed: '.$e->getMessage()], 503);
         }
     }
 
     private function buildCategorizePrompt(string $description, string $type): string
     {
         $typeLabel = $type === 'income' ? 'income' : 'expense';
+
         return <<<PROMPT
 Categorize this {$typeLabel} transaction by predicting the BEST MATCHING category names semantically (NOT ids), then call list_categories(type="{$type}"), then MATCH your predictions to the exact names/IDs in the tree_structure response.
 
@@ -180,9 +183,9 @@ PROMPT;
     }
 
     /**
-     * Process categorize events from tool streaming, extract category tool results, 
+     * Process categorize events from tool streaming, extract category tool results,
      * semantically match LLM predictions to DB categories, normalize tree IDs.
-     * 
+     *
      * @return array{category_id: int, subcategory_id: int, confidence: string}|null
      */
     private function handleCategorizeEvents(array $events, string $type): ?array
@@ -193,7 +196,7 @@ PROMPT;
         foreach ($events as $event) {
             if ($event instanceof ToolResultEvent && $event->toolCall->name === 'list_categories') {
                 $toolResult = json_decode($event->content, true);
-                if (!($toolResult['success'] ?? false)) {
+                if (! ($toolResult['success'] ?? false)) {
                     return null;
                 }
                 break; // Assume single tool call per categorize
@@ -207,7 +210,7 @@ PROMPT;
         }
 
         $tree = $toolResult['tree_structure'];
-        
+
         // Parse final text for JSON (LLM final output after tool)
         $finalJson = $this->decodeJsonResponse($finalText);
         if ($finalJson && isset($finalJson['category_id'], $finalJson['subcategory_id'])) {
@@ -221,6 +224,7 @@ PROMPT;
 
         // Fallback: simple first-match normalization using existing logic
         $categories = $this->fetchCategoriesByType($type);
+
         return $this->normalizeToTreeIds(null, null, $type); // Uses existing fallbacks
     }
 
@@ -230,8 +234,7 @@ PROMPT;
         if ($type === 'income') {
             $incomeRoot = Category::query()
                 ->active()
-                ->parent()
-                ->where('code', 'INCOME')
+                ->incomeRoot()
                 ->with(['activeChildren' => fn ($q) => $q->orderBy('name')])
                 ->first();
 
@@ -251,8 +254,7 @@ PROMPT;
 
         return Category::query()
             ->active()
-            ->parent()
-            ->whereNotIn('code', ['INCOME', 'ACCOUNTTR'])
+            ->expenseParent()
             ->with(['activeChildren' => fn ($q) => $q->orderBy('name')])
             ->orderBy('name')
             ->get()
@@ -332,7 +334,7 @@ PROMPT;
     /**
      * Prefer the best sibling under the resolved parent when the wording matches another child much better than the current leaf (e.g. model returns Loans but picks Mortgage alphabetically).
      *
-     * @param array{category_id: int, subcategory_id: int} $normalized
+     * @param  array{category_id: int, subcategory_id: int}  $normalized
      * @return array{category_id: int, subcategory_id: int}
      */
     private function refineExpenseSiblingByDescription(string $description, array $normalized): array
@@ -463,8 +465,7 @@ PROMPT;
     {
         $incomeRoot = Category::query()
             ->active()
-            ->parent()
-            ->where('code', 'INCOME')
+            ->incomeRoot()
             ->with(['activeChildren' => fn ($q) => $q->orderBy('name')])
             ->first();
 
@@ -495,8 +496,7 @@ PROMPT;
     {
         $expenseParents = Category::query()
             ->active()
-            ->parent()
-            ->whereNotIn('code', ['INCOME', 'ACCOUNTTR'])
+            ->expenseParent()
             ->with(['activeChildren' => fn ($q) => $q->orderBy('name')])
             ->get()
             ->keyBy('id');
@@ -509,7 +509,7 @@ PROMPT;
             $child = Category::query()->active()->whereKey($childId)->first();
             if ($child && $child->parent_id) {
                 $parentOfChild = Category::query()->find($child->parent_id);
-                if ($parentOfChild && $parentOfChild->code === 'INCOME') {
+                if ($parentOfChild && $this->isNonExpenseRoot($parentOfChild)) {
                     return $this->fallbackExpenseLeaf($expenseParents);
                 }
 
@@ -546,9 +546,8 @@ PROMPT;
     {
         $other = Category::query()
             ->active()
-            ->parent()
+            ->expenseParent()
             ->where('name', 'Other')
-            ->whereNotIn('code', ['INCOME', 'ACCOUNTTR'])
             ->with(['activeChildren' => fn ($q) => $q->orderBy('name')])
             ->first();
 
@@ -570,7 +569,7 @@ PROMPT;
         $anyChild = Category::query()
             ->active()
             ->whereNotNull('parent_id')
-            ->whereHas('parent', fn ($q) => $q->whereNull('parent_id')->whereNotIn('code', ['INCOME', 'ACCOUNTTR']))
+            ->whereHas('parent', fn ($q) => $q->expenseParent())
             ->orderBy('id')
             ->first();
 
@@ -582,5 +581,14 @@ PROMPT;
         }
 
         return null;
+    }
+
+    private function isNonExpenseRoot(Category $category): bool
+    {
+        $code = strtolower((string) $category->code);
+        $name = strtolower((string) $category->name);
+
+        return in_array($code, ['income', 'accounttr', 'account_transfer'], true)
+            || in_array($name, ['income', 'account transfer'], true);
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -37,7 +37,10 @@ class HandleInertiaRequests extends Middleware
     {
         return [
             ...parent::share($request),
-            //
+            'flash' => [
+                'success' => fn () => $request->session()->get('success'),
+                'warning' => fn () => $request->session()->get('warning'),
+            ],
         ];
     }
 }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -22,12 +22,14 @@ class Category extends Model
     protected $casts = [
         'is_active' => 'boolean',
     ];
-    
+
     // Category types as constants (you can add more as needed)
     public const TYPE_INCOME = 'income';
+
     public const TYPE_EXPENSE = 'expense';
+
     public const TYPE_BOTH = 'both';
-    
+
     // Get all available category types
     public static function getTypes(): array
     {
@@ -54,6 +56,24 @@ class Category extends Model
     public function scopeChild($query)
     {
         return $query->whereNotNull('parent_id');
+    }
+
+    public function scopeIncomeRoot($query)
+    {
+        return $query->parent()
+            ->where(function ($q) {
+                $q->whereRaw('LOWER(COALESCE(code, ?)) = ?', ['', 'income'])
+                    ->orWhereRaw('LOWER(name) = ?', ['income']);
+            });
+    }
+
+    public function scopeExpenseParent($query)
+    {
+        return $query->parent()
+            ->whereNot(function ($q) {
+                $q->whereRaw('LOWER(COALESCE(code, ?)) IN (?, ?, ?)', ['', 'income', 'accounttr', 'account_transfer'])
+                    ->orWhereRaw('LOWER(name) IN (?, ?)', ['income', 'account transfer']);
+            });
     }
 
     // Relationship: Parent category
@@ -89,7 +109,7 @@ class Category extends Model
     // Get full category name (including parent if exists)
     public function getFullNameAttribute()
     {
-        return $this->parent ? $this->parent->name . ' > ' . $this->name : $this->name;
+        return $this->parent ? $this->parent->name.' > '.$this->name : $this->name;
     }
 
     // Get category hierarchy level
@@ -107,7 +127,7 @@ class Category extends Model
     // Check if category is child/sub-category
     public function isChild()
     {
-        return !is_null($this->parent_id);
+        return ! is_null($this->parent_id);
     }
 
     // Calculate total transaction amount for this category only
@@ -122,18 +142,18 @@ class Category extends Model
         if ($this->isParent()) {
             // For parent categories, sum all children's transaction amounts using efficient DB query
             $childrenIds = $this->children->pluck('id')->toArray();
-            
+
             // If no children, just return parent's total
             if (empty($childrenIds)) {
                 return $this->transactions()->sum('amount');
             }
-            
+
             // Include parent ID as well (in case parent has direct transactions)
             $allIds = array_merge($childrenIds, [$this->id]);
-            
+
             return Transaction::whereIn('category_id', $allIds)->sum('amount');
         }
-        
+
         // For child categories, just return their own total
         return $this->total_amount;
     }
@@ -150,18 +170,18 @@ class Category extends Model
         if ($this->isParent()) {
             // For parent categories, count all children's transactions using efficient DB query
             $childrenIds = $this->children->pluck('id')->toArray();
-            
+
             // If no children, just return parent's count
             if (empty($childrenIds)) {
                 return $this->transactions()->count();
             }
-            
+
             // Include parent ID as well (in case parent has direct transactions)
             $allIds = array_merge($childrenIds, [$this->id]);
-            
+
             return Transaction::whereIn('category_id', $allIds)->count();
         }
-        
+
         return $this->transaction_count;
     }
 }

--- a/resources/js/Pages/Accounts/Edit.jsx
+++ b/resources/js/Pages/Accounts/Edit.jsx
@@ -11,9 +11,12 @@ export default function Edit({ account, accountTypes }) {
         bank_name: account.bank_name || '',
         account_number: account.account_number || '',
         ifsc_code: account.ifsc_code || '',
-        opening_balance: account.opening_balance || '0.00',
-        current_balance: account.current_balance || '0.00',
-        credit_limit: account.credit_limit || '0.00',
+        opening_balance:
+            account.opening_balance != null && account.opening_balance !== '' ? String(account.opening_balance) : '0.00',
+        current_balance:
+            account.current_balance != null && account.current_balance !== '' ? String(account.current_balance) : '0.00',
+        credit_limit:
+            account.credit_limit != null && account.credit_limit !== '' ? String(account.credit_limit) : '0.00',
         is_active: account.is_active ?? true,
     });
 

--- a/resources/js/utils/inputValidation.js
+++ b/resources/js/utils/inputValidation.js
@@ -226,9 +226,10 @@ export const validateTags = (tags, maxTags = 10, maxTagLength = 30) => {
 };
 
 /**
- * Real-time amount input handler
+ * Real-time amount input handler.
+ * Either: handleAmountInput(e, (value) => { ... })  OR  handleAmountInput(e, setData, 'fieldKey') for useForm.setData.
  */
-export const handleAmountInput = (event, setValue) => {
+export const handleAmountInput = (event, setter, fieldKey = undefined) => {
     let value = event.target.value;
 
     value = value.replace(/[^\d.-]/g, '');
@@ -246,7 +247,11 @@ export const handleAmountInput = (event, setValue) => {
         value = value.replace(/-/g, '');
     }
 
-    setValue(value);
+    if (typeof fieldKey === 'string') {
+        setter(fieldKey, value);
+    } else {
+        setter(value);
+    }
 };
 
 /**

--- a/tests/Feature/AiCategorizeTest.php
+++ b/tests/Feature/AiCategorizeTest.php
@@ -102,6 +102,111 @@ class AiCategorizeTest extends TestCase
             ->assertJsonPath('confidence', 'medium');
     }
 
+    public function test_categorize_income_accepts_seeded_lowercase_income_code(): void
+    {
+        $incomeRoot = Category::factory()->parent()->create([
+            'code' => 'income',
+            'name' => 'Income',
+            'is_active' => true,
+        ]);
+        $salary = Category::factory()->create([
+            'parent_id' => $incomeRoot->id,
+            'name' => 'Salary',
+            'is_active' => true,
+        ]);
+
+        Prism::fake([
+            new TextResponse(
+                steps: collect([]),
+                text: json_encode([
+                    'category_id' => $incomeRoot->id,
+                    'subcategory_id' => $salary->id,
+                    'confidence' => 'high',
+                    'reason' => 'Payroll deposit',
+                ]),
+                finishReason: FinishReason::Stop,
+                toolCalls: [],
+                toolResults: [],
+                usage: new Usage(0, 0),
+                meta: new Meta('fake', 'fake'),
+                messages: collect([]),
+            ),
+        ]);
+
+        $response = $this->postJson('/ai/categorize', [
+            'description' => 'SALARY CREDIT',
+            'type' => 'income',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('category_id', $incomeRoot->id)
+            ->assertJsonPath('subcategory_id', $salary->id)
+            ->assertJsonPath('confidence', 'high');
+    }
+
+    public function test_categorize_expense_fallback_excludes_income_and_account_transfer_roots(): void
+    {
+        $incomeRoot = Category::factory()->parent()->create([
+            'code' => 'income',
+            'name' => 'Income',
+            'is_active' => true,
+        ]);
+        Category::factory()->create([
+            'parent_id' => $incomeRoot->id,
+            'name' => 'Salary',
+            'is_active' => true,
+        ]);
+
+        $transferRoot = Category::factory()->parent()->create([
+            'code' => 'ACCOUNT_TRANSFER',
+            'name' => 'Account Transfer',
+            'is_active' => true,
+        ]);
+        $transferChild = Category::factory()->create([
+            'parent_id' => $transferRoot->id,
+            'name' => 'Account Transfer',
+            'is_active' => true,
+        ]);
+
+        $food = Category::factory()->parent()->create([
+            'code' => 'food',
+            'name' => 'Food',
+            'is_active' => true,
+        ]);
+        $groceries = Category::factory()->create([
+            'parent_id' => $food->id,
+            'name' => 'Groceries',
+            'is_active' => true,
+        ]);
+
+        Prism::fake([
+            new TextResponse(
+                steps: collect([]),
+                text: json_encode([
+                    'category_id' => $transferRoot->id,
+                    'subcategory_id' => $transferChild->id,
+                    'confidence' => 'low',
+                    'reason' => 'Wrong branch',
+                ]),
+                finishReason: FinishReason::Stop,
+                toolCalls: [],
+                toolResults: [],
+                usage: new Usage(0, 0),
+                meta: new Meta('fake', 'fake'),
+                messages: collect([]),
+            ),
+        ]);
+
+        $response = $this->postJson('/ai/categorize', [
+            'description' => 'GROCERY STORE',
+            'type' => 'expense',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('category_id', $food->id)
+            ->assertJsonPath('subcategory_id', $groceries->id);
+    }
+
     public function test_categorize_expense_falls_back_when_ai_returns_income_child(): void
     {
         $incomeRoot = Category::factory()->parent()->create([


### PR DESCRIPTION
## Summary
- Adds reusable Category scopes for income roots and expense parents that tolerate seeded lowercase/alternate category codes.
- Updates AI categorization and list_categories filtering to use those scopes.
- Prevents income/account-transfer roots from leaking into expense fallback normalization.
- Adds regression coverage for lowercase seeded income code and account-transfer exclusion.

## Verification
- vendor/bin/pint app/Models/Category.php app/Http/Controllers/AiController.php app/AI/Tools/ListCategoriesTool.php tests/Feature/AiCategorizeTest.php
- php artisan test tests/Feature/AiCategorizeTest.php
- php artisan test tests/Feature/AiCategorizeTest.php tests/Feature/StatementReconcileTest.php
- git diff --check

## Notes
- Stacked on PR #52 / branch codex/51-dirty-tree-cleanup so this PR shows only COD-43 category mapping changes.
- After PR #52 merges, this can be retargeted to llm-integration if GitHub does not update it automatically.
