### PR TITLE
fix: correct internal account transfers and reporting

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+> time field on each row
+> popup to open fulll edit form to fill remaining fields if user want to
+> enable transafer feature as well on transafer to category , subcategory is reuired
+> Scan db with  for all transaction and add the marker for mis balance info mark every month
+> import the corrected transaction with balance adjustment
+> telegram command to log mood , meal , water

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,0 @@
-> time field on each row
-> popup to open fulll edit form to fill remaining fields if user want to
-> enable transafer feature as well on transafer to category , subcategory is reuired
-> Scan db with  for all transaction and add the marker for mis balance info mark every month
-> import the corrected transaction with balance adjustment
-> telegram command to log mood , meal , water

--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -6,6 +6,7 @@ use App\Models\Account;
 use App\Models\Budget;
 use App\Models\Category;
 use App\Models\Transaction;
+use App\Services\AccountTransferService;
 use App\Services\TransactionFilterService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
@@ -28,8 +29,8 @@ class TransactionController extends Controller
 
         $filteredQuery = clone $query;
 
-        $totalIncome = $filteredQuery->where('transaction_type', 'income')->sum('amount');
-        $totalExpenses = (clone $query)->where('transaction_type', '!=', 'income')->sum('amount');
+        $totalIncome = $filteredQuery->where('transaction_type', Transaction::TYPE_INCOME)->sum('amount');
+        $totalExpenses = (clone $query)->where('transaction_type', Transaction::TYPE_EXPENSE)->sum('amount');
         $netBalance = $totalIncome - $totalExpenses;
 
         $totals = [
@@ -133,7 +134,7 @@ class TransactionController extends Controller
         $amount = (string) $transaction->amount;
         $debit = '';
         $credit = '';
-        if ($transaction->transaction_type === 'income') {
+        if ($transaction->getBalanceImpact() > 0) {
             $credit = $amount;
         } else {
             $debit = $amount;
@@ -176,88 +177,34 @@ class TransactionController extends Controller
      * - Expense transactions: Subtract from account balance
      * - Transfer transactions: Creates two entries (outgoing + incoming)
      */
-    public function store(Request $request)
+    public function store(Request $request, AccountTransferService $transferService)
     {
         $validated = $request->validate([
             'account_id' => 'required|exists:accounts,id',
-            'category_id' => 'nullable|exists:categories,id',
-            'transaction_type' => 'required|string|max:20',
-            'amount' => 'required|numeric',
+            'category_id' => 'nullable|required_unless:transaction_type,transfer|exists:categories,id',
+            'transaction_type' => 'required|in:income,expense,transfer',
+            'amount' => 'required|numeric|gt:0',
             'description' => 'nullable|string',
             'transaction_date' => 'required|date',
             'transaction_time' => 'nullable|date_format:H:i',
-            'payment_method' => 'required_unless:transaction_type,transfer|string|max:50',
+            'payment_method' => 'nullable|required_unless:transaction_type,transfer|string|max:50',
             'reference_number' => 'nullable|string|max:100',
             'tags' => 'nullable|string',
             'location' => 'nullable|string',
-            'transfer_to_account_id' => 'nullable|required_if:transaction_type,transfer|exists:accounts,id',
+            'transfer_to_account_id' => 'nullable|required_if:transaction_type,transfer|different:account_id|exists:accounts,id',
         ]);
 
-        // Handle account transfer - create two transactions
-        if ($validated['transaction_type'] === 'transfer') {
-            // Get the account transfer category
-            $transferCategory = Category::where('code', 'ACCOUNTTR')->first();
-
-            if (! $transferCategory) {
-                return Redirect::back()
-                    ->withErrors(['transfer' => 'Account transfer category not found. Please contact administrator.']);
-            }
-
-            // Get a subcategory under ACCOUNTTR or use the parent if no subcategories exist
-            $transferSubcategory = Category::where('parent_id', $transferCategory->id)->first();
-            $categoryId = $transferSubcategory ? $transferSubcategory->id : $transferCategory->id;
-
-            // Create outgoing transaction (from source account)
-            Transaction::create([
-                'account_id' => $validated['account_id'],
-                'category_id' => $categoryId,
-                'transaction_type' => 'transfer',
-                'amount' => $validated['amount'],
-                'description' => $validated['description'] ?? 'Transfer to account',
-                'transaction_date' => $validated['transaction_date'],
-                'transaction_time' => $validated['transaction_time'] ?? null,
-                'payment_method' => $validated['payment_method'] ?? null,
-                'reference_number' => $validated['reference_number'] ?? null,
-                'tags' => $validated['tags'] ?? null,
-                'location' => $validated['location'] ?? null,
-            ]);
-
-            // Get income category for the incoming transaction
-            $incomeCategory = Category::where('code', 'INCOME')->first();
-
-            if (! $incomeCategory) {
-                return Redirect::back()
-                    ->withErrors(['transfer' => 'Income category not found. Please contact administrator.']);
-            }
-
-            // Get a subcategory under INCOME or use the parent if no subcategories exist
-            $incomeSubcategory = Category::where('parent_id', $incomeCategory->id)->first();
-            $incomeCategoryId = $incomeSubcategory ? $incomeSubcategory->id : $incomeCategory->id;
-
-            // Create incoming transaction (to destination account)
-            Transaction::create([
-                'account_id' => $validated['transfer_to_account_id'],
-                'category_id' => $incomeCategoryId,
-                'transaction_type' => 'income',
-                'amount' => $validated['amount'],
-                'description' => $validated['description'] ?? 'Transfer from account',
-                'transaction_date' => $validated['transaction_date'],
-                'transaction_time' => $validated['transaction_time'] ?? null,
-                'payment_method' => $validated['payment_method'] ?? null,
-                'reference_number' => $validated['reference_number'] ?? null,
-                'tags' => $validated['tags'] ?? null,
-                'location' => $validated['location'] ?? null,
-            ]);
+        if ($validated['transaction_type'] === Transaction::TYPE_TRANSFER) {
+            $transferService->create($validated);
 
             return Redirect::route('transactions.index')
                 ->with('success', 'Account transfer completed successfully.');
         }
 
-        // Regular transaction (income or expense)
-        $transaction = Transaction::create($validated);
+        unset($validated['transfer_to_account_id']);
+        Transaction::create($validated);
 
-        // Check budget alerts for expense transactions
-        if ($validated['transaction_type'] === 'expense' && isset($validated['category_id'])) {
+        if ($validated['transaction_type'] === Transaction::TYPE_EXPENSE && isset($validated['category_id'])) {
             $budgetAlerts = $this->checkBudgetAlerts($validated['category_id'], $validated['transaction_date']);
 
             if (! empty($budgetAlerts)) {
@@ -284,8 +231,14 @@ class TransactionController extends Controller
     /**
      * Show the form for editing the specified transaction.
      */
-    public function edit(Transaction $transaction)
+    public function edit(Transaction $transaction, AccountTransferService $transferService)
     {
+        if ($transaction->transaction_type === Transaction::TYPE_TRANSFER) {
+            $legs = $transferService->pair($transaction);
+            $transaction = $legs['outgoing'];
+            $transaction->setAttribute('transfer_to_account_id', $legs['incoming']->account_id);
+        }
+
         // Load the transaction with its relationships
         $transaction->load(['category.parent', 'account']);
         $transaction->transaction_time = $this->timeInputValue($transaction->transaction_time);
@@ -326,24 +279,32 @@ class TransactionController extends Controller
      * - If account changes: Old account is reverted, new account is updated
      * - If amount/type changes: Balance is recalculated accordingly
      */
-    public function update(Request $request, Transaction $transaction)
+    public function update(Request $request, Transaction $transaction, AccountTransferService $transferService)
     {
         $validated = $request->validate([
             'account_id' => 'required|exists:accounts,id',
-            'category_id' => 'required|exists:categories,id',
-            'transaction_type' => 'nullable|string|max:20',
-            'amount' => 'required|numeric',
+            'category_id' => 'nullable|required_unless:transaction_type,transfer|exists:categories,id',
+            'transaction_type' => 'required|in:income,expense,transfer',
+            'amount' => 'required|numeric|gt:0',
             'description' => 'nullable|string',
             'expensed_date' => 'required|date',
             'transaction_time' => 'nullable|date_format:H:i',
-            'payment_method' => 'required_unless:transaction_type,transfer|string|max:50',
+            'payment_method' => 'nullable|required_unless:transaction_type,transfer|string|max:50',
             'reference_number' => 'nullable|string|max:100',
             'tags' => 'nullable|string',
             'payee_payer' => 'nullable|string',
             'tax' => 'nullable|numeric',
             'status' => 'nullable|string',
             'notes' => 'nullable|string',
+            'transfer_to_account_id' => 'nullable|required_if:transaction_type,transfer|different:account_id|exists:accounts,id',
         ]);
+
+        $isExistingTransfer = $transaction->transaction_type === Transaction::TYPE_TRANSFER;
+        if ($isExistingTransfer !== ($validated['transaction_type'] === Transaction::TYPE_TRANSFER)) {
+            throw ValidationException::withMessages([
+                'transaction_type' => 'Converting between transfers and regular transactions is not supported.',
+            ]);
+        }
 
         // Map expensed_date to transaction_date for database compatibility
         if (isset($validated['expensed_date'])) {
@@ -351,7 +312,12 @@ class TransactionController extends Controller
             unset($validated['expensed_date']);
         }
 
-        $transaction->update($validated);
+        if ($isExistingTransfer) {
+            $transferService->update($transaction, $validated);
+        } else {
+            unset($validated['transfer_to_account_id']);
+            $transaction->update($validated);
+        }
 
         return Redirect::route('transactions.index')
             ->with('success', 'Transaction updated successfully.');
@@ -363,9 +329,13 @@ class TransactionController extends Controller
      * Note: Account balance is automatically reverted via Transaction model events
      * - The transaction's impact on the account balance is reversed
      */
-    public function destroy(Transaction $transaction)
+    public function destroy(Transaction $transaction, AccountTransferService $transferService)
     {
-        $transaction->delete();
+        if ($transaction->transaction_type === Transaction::TYPE_TRANSFER) {
+            $transferService->delete($transaction);
+        } else {
+            $transaction->delete();
+        }
 
         return Redirect::route('transactions.index')
             ->with('success', 'Transaction deleted successfully.');
@@ -377,7 +347,7 @@ class TransactionController extends Controller
      * Note: Account balances are automatically reverted via Transaction model events
      * - Each transaction is deleted individually to trigger the model's deleted event
      */
-    public function bulkDestroy(Request $request)
+    public function bulkDestroy(Request $request, AccountTransferService $transferService)
     {
         $validated = $request->validate([
             'ids' => 'required|array',
@@ -388,8 +358,18 @@ class TransactionController extends Controller
         $transactions = Transaction::whereIn('id', $validated['ids'])->get();
         $count = 0;
 
+        $processedGroups = [];
         foreach ($transactions as $transaction) {
-            $transaction->delete();
+            if ($transaction->transaction_type === Transaction::TYPE_TRANSFER) {
+                if (isset($processedGroups[$transaction->transfer_group_id])) {
+                    continue;
+                }
+
+                $transferService->delete($transaction);
+                $processedGroups[$transaction->transfer_group_id] = true;
+            } else {
+                $transaction->delete();
+            }
             $count++;
         }
 
@@ -403,11 +383,11 @@ class TransactionController extends Controller
     public function getDashboardStats()
     {
         // Get total income (where transaction_type is 'income')
-        $totalIncome = Transaction::where('transaction_type', 'income')
+        $totalIncome = Transaction::where('transaction_type', Transaction::TYPE_INCOME)
             ->sum('amount');
 
-        // Get total expenses (where transaction_type is not 'income')
-        $totalExpenses = Transaction::where('transaction_type', '!=', 'income')
+        // Transfers only move money between accounts and are not expenses.
+        $totalExpenses = Transaction::where('transaction_type', Transaction::TYPE_EXPENSE)
             ->sum('amount');
 
         // Convert negative expenses to positive for display

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -31,9 +31,13 @@ class Account extends Model
 
     // Account types as constants
     public const TYPE_SAVINGS = 'savings';
+
     public const TYPE_CURRENT = 'current';
+
     public const TYPE_CREDIT_CARD = 'credit_card';
+
     public const TYPE_CASH = 'cash';
+
     public const TYPE_INVESTMENT = 'investment';
 
     // Get all available account types
@@ -87,7 +91,7 @@ class Account extends Model
     // Relationship with transactions
     public function transactions()
     {
-        return $this->hasMany(\App\Models\Transaction::class);
+        return $this->hasMany(Transaction::class);
     }
 
     /**
@@ -97,17 +101,14 @@ class Account extends Model
     public function recalculateBalance()
     {
         $transactions = $this->transactions()
-            ->select('transaction_type', 'amount')
+            ->with('category:id,code')
+            ->select('id', 'category_id', 'transaction_type', 'amount')
             ->get();
 
-        $balance = $this->opening_balance;
+        $balance = (float) $this->opening_balance;
 
         foreach ($transactions as $transaction) {
-            if ($transaction->transaction_type === 'income') {
-                $balance += $transaction->amount;
-            } else {
-                $balance -= $transaction->amount;
-            }
+            $balance += $transaction->getBalanceImpact();
         }
 
         $this->current_balance = $balance;

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -2,12 +2,24 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
 class Transaction extends Model
 {
-    protected $table = 'transactions';
     use HasFactory;
+
+    public const TYPE_INCOME = 'income';
+
+    public const TYPE_EXPENSE = 'expense';
+
+    public const TYPE_TRANSFER = 'transfer';
+
+    public const CATEGORY_TRANSFER_INCOMING = 'TRANSFER_INCOMING';
+
+    public const CATEGORY_TRANSFER_OUTGOING = 'TRANSFER_OUTGOING';
+
+    protected $table = 'transactions';
 
     /**
      * The relationships that should always be loaded.
@@ -20,6 +32,7 @@ class Transaction extends Model
         'account_id',
         'category_id',
         'transaction_type',
+        'transfer_group_id',
         'amount',
         'description',
         'transaction_date',
@@ -74,60 +87,72 @@ class Transaction extends Model
     /**
      * Update the account balance based on the transaction
      *
-     * @param string $operation 'add', 'subtract', or 'update'
+     * @param  string  $operation  'add', 'subtract', or 'update'
      */
+    public static function balanceImpact(string $type, float|int|string $amount, ?string $categoryCode = null): float
+    {
+        $amount = (float) $amount;
+
+        if ($type === self::TYPE_INCOME || $categoryCode === self::CATEGORY_TRANSFER_INCOMING) {
+            return $amount;
+        }
+
+        return -$amount;
+    }
+
+    public function getBalanceImpact(): float
+    {
+        return self::balanceImpact(
+            $this->transaction_type,
+            $this->amount,
+            $this->category?->code
+        );
+    }
+
     public function updateAccountBalance($operation = 'add')
     {
-        $account = $this->account;
+        // Resolve by the current foreign key instead of a potentially stale loaded relation.
+        $account = Account::find($this->account_id);
 
-        if (!$account) {
+        if (! $account) {
             return;
         }
 
-        // Calculate the amount impact based on transaction type
-        // For income: add to balance
-        // For expense: subtract from balance
-        $amountImpact = $this->transaction_type === 'income' ? $this->amount : -$this->amount;
+        $amountImpact = $this->getBalanceImpact();
 
         switch ($operation) {
             case 'add':
-                // Adding a new transaction
                 $account->current_balance += $amountImpact;
                 break;
 
             case 'subtract':
-                // Removing a transaction (revert its effect)
                 $account->current_balance -= $amountImpact;
                 break;
 
             case 'update':
-                // Get the original values before the update
                 $originalAccountId = $this->getOriginal('account_id');
-                $originalAmount = $this->getOriginal('amount');
-                $originalType = $this->getOriginal('transaction_type');
+                $originalCategoryCode = Category::find($this->getOriginal('category_id'))?->code;
+                $oldAmountImpact = self::balanceImpact(
+                    $this->getOriginal('transaction_type'),
+                    $this->getOriginal('amount'),
+                    $originalCategoryCode
+                );
 
-                // If the account changed, we need to update both accounts
                 if ($originalAccountId != $this->account_id) {
-                    // Revert the old account
                     $oldAccount = Account::find($originalAccountId);
                     if ($oldAccount) {
-                        $oldAmountImpact = $originalType === 'income' ? $originalAmount : -$originalAmount;
                         $oldAccount->current_balance -= $oldAmountImpact;
                         $oldAccount->save();
                     }
 
-                    // Add to new account
                     $account->current_balance += $amountImpact;
                 } else {
-                    // Same account, just adjust the difference
-                    $oldAmountImpact = $originalType === 'income' ? $originalAmount : -$originalAmount;
-                    $account->current_balance -= $oldAmountImpact; // Revert old impact
-                    $account->current_balance += $amountImpact;     // Apply new impact
+                    $account->current_balance -= $oldAmountImpact;
+                    $account->current_balance += $amountImpact;
                 }
                 break;
         }
 
         $account->save();
     }
-
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -20,9 +19,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        $root = (string) config('app.url');
-        if ($root !== '') {
-            URL::forceRootUrl(rtrim($root, '/'));
-        }
+        // Use the active HTTP request origin for browser redirects.
     }
 }

--- a/app/Services/AccountTransferService.php
+++ b/app/Services/AccountTransferService.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Category;
+use App\Models\Transaction;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+class AccountTransferService
+{
+    public function pair(Transaction $transaction): array
+    {
+        return $this->findGroupLegs($transaction, false);
+    }
+
+    public function create(array $data): array
+    {
+        return DB::transaction(function () use ($data) {
+            $categories = $this->transferCategories();
+            $groupId = (string) Str::uuid();
+            $common = $this->commonAttributes($data, $groupId);
+
+            $outgoing = Transaction::create(array_merge($common, [
+                'account_id' => $data['account_id'],
+                'category_id' => $categories['outgoing']->id,
+            ]));
+
+            $incoming = Transaction::create(array_merge($common, [
+                'account_id' => $data['transfer_to_account_id'],
+                'category_id' => $categories['incoming']->id,
+            ]));
+
+            return [$outgoing, $incoming];
+        });
+    }
+
+    public function update(Transaction $transaction, array $data): array
+    {
+        return DB::transaction(function () use ($transaction, $data) {
+            $legs = $this->findGroupLegs($transaction);
+            $categories = $this->transferCategories();
+            $common = $this->commonAttributes($data, $transaction->transfer_group_id);
+            $outgoing = $legs['outgoing'];
+            $incoming = $legs['incoming'];
+
+            $outgoing->update(array_merge($common, [
+                'account_id' => $data['account_id'],
+                'category_id' => $categories['outgoing']->id,
+            ]));
+            $incoming->update(array_merge($common, [
+                'account_id' => $data['transfer_to_account_id'],
+                'category_id' => $categories['incoming']->id,
+            ]));
+
+            return [$outgoing->fresh(), $incoming->fresh()];
+        });
+    }
+
+    public function delete(Transaction $transaction): void
+    {
+        DB::transaction(function () use ($transaction) {
+            foreach ($this->findGroupLegs($transaction) as $leg) {
+                $leg->delete();
+            }
+        });
+    }
+
+    private function findGroupLegs(Transaction $transaction, bool $lock = true): array
+    {
+        if (! $transaction->transfer_group_id) {
+            throw new RuntimeException('Transfer is missing its group ID.');
+        }
+
+        $query = Transaction::query()
+            ->where('transfer_group_id', $transaction->transfer_group_id);
+
+        if ($lock) {
+            $query->lockForUpdate();
+        }
+
+        $legs = $query->get();
+
+        if ($legs->count() !== 2) {
+            throw new RuntimeException('Transfer group must contain exactly two legs.');
+        }
+
+        $byCode = $legs->keyBy(fn (Transaction $leg) => $leg->category?->code);
+        if (! $byCode->has(Transaction::CATEGORY_TRANSFER_INCOMING)
+            || ! $byCode->has(Transaction::CATEGORY_TRANSFER_OUTGOING)) {
+            throw new RuntimeException('Transfer group has invalid directions.');
+        }
+
+        return [
+            'incoming' => $byCode[Transaction::CATEGORY_TRANSFER_INCOMING],
+            'outgoing' => $byCode[Transaction::CATEGORY_TRANSFER_OUTGOING],
+        ];
+    }
+
+    private function transferCategories(): array
+    {
+        $categories = Category::query()
+            ->whereIn('code', [
+                Transaction::CATEGORY_TRANSFER_INCOMING,
+                Transaction::CATEGORY_TRANSFER_OUTGOING,
+            ])
+            ->get()
+            ->keyBy('code');
+
+        if (! $categories->has(Transaction::CATEGORY_TRANSFER_INCOMING)
+            || ! $categories->has(Transaction::CATEGORY_TRANSFER_OUTGOING)) {
+            throw new RuntimeException('Account transfer categories are not configured.');
+        }
+
+        return [
+            'incoming' => $categories[Transaction::CATEGORY_TRANSFER_INCOMING],
+            'outgoing' => $categories[Transaction::CATEGORY_TRANSFER_OUTGOING],
+        ];
+    }
+
+    private function commonAttributes(array $data, string $groupId): array
+    {
+        return [
+            'transaction_type' => Transaction::TYPE_TRANSFER,
+            'transfer_group_id' => $groupId,
+            'amount' => $data['amount'],
+            'description' => $data['description'] ?? null,
+            'transaction_date' => $data['transaction_date'],
+            'transaction_time' => $data['transaction_time'] ?? null,
+            'payment_method' => null,
+            'reference_number' => $data['reference_number'] ?? null,
+            'tags' => $data['tags'] ?? null,
+            'location' => $data['location'] ?? null,
+        ];
+    }
+}

--- a/database/migrations/2026_07_18_000001_add_account_transfer_subcategories.php
+++ b/database/migrations/2026_07_18_000001_add_account_transfer_subcategories.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $root = DB::table('categories')
+            ->whereNull('parent_id')
+            ->whereRaw('LOWER(code) = ?', ['account_transfer'])
+            ->first();
+
+        if (! $root) {
+            return;
+        }
+
+        $duplicates = DB::table('categories')
+            ->whereNotNull('parent_id')
+            ->whereRaw('LOWER(code) = ?', ['account_transfer'])
+            ->get();
+
+        foreach ($duplicates as $duplicate) {
+            if (DB::table('transactions')->where('category_id', $duplicate->id)->exists()) {
+                throw new RuntimeException('Cannot remove duplicate ACCOUNT_TRANSFER category because transactions reference it.');
+            }
+
+            DB::table('categories')->where('id', $duplicate->id)->delete();
+        }
+
+        $now = now();
+        foreach ([
+            ['name' => 'Transfer Incoming', 'code' => 'TRANSFER_INCOMING'],
+            ['name' => 'Transfer Outgoing', 'code' => 'TRANSFER_OUTGOING'],
+        ] as $category) {
+            DB::table('categories')->updateOrInsert(
+                ['parent_id' => $root->id, 'code' => $category['code']],
+                [
+                    'name' => $category['name'],
+                    'description' => null,
+                    'icon' => 'fas fa-exchange-alt',
+                    'color' => '#6c757d',
+                    'is_active' => true,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]
+            );
+        }
+    }
+
+    public function down(): void
+    {
+        $rootIds = DB::table('categories')
+            ->whereNull('parent_id')
+            ->whereRaw('LOWER(code) = ?', ['account_transfer'])
+            ->pluck('id');
+
+        DB::table('categories')
+            ->whereIn('parent_id', $rootIds)
+            ->whereIn('code', ['TRANSFER_INCOMING', 'TRANSFER_OUTGOING'])
+            ->delete();
+    }
+};

--- a/database/migrations/2026_07_18_000002_add_transfer_group_id_to_transactions_table.php
+++ b/database/migrations/2026_07_18_000002_add_transfer_group_id_to_transactions_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->uuid('transfer_group_id')->nullable()->index()->after('transaction_type');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->dropColumn('transfer_group_id');
+        });
+    }
+};

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -118,10 +118,11 @@ class CategorySeeder extends Seeder
             ['id' => 107, 'parent_id' => 90, 'name' => 'Personal Savings', 'code' => 'PERSONAL_SAVINGS', 'description' => null, 'icon' => null, 'color' => null],
             ['id' => 108, 'parent_id' => 90, 'name' => 'Other', 'code' => 'OTHER', 'description' => null, 'icon' => null, 'color' => null],
             ['id' => 109, 'parent_id' => 90, 'name' => 'Snack', 'code' => 'SNACK', 'description' => null, 'icon' => null, 'color' => null],
-            ['id' => 110, 'parent_id' => 90, 'name' => 'Account Transfer', 'code' => 'ACCOUNT_TRANSFER', 'description' => null, 'icon' => null, 'color' => null],
             ['id' => 111, 'parent_id' => null, 'name' => 'Loan', 'code' => 'loan', 'description' => null, 'icon' => null, 'color' => null],
             ['id' => 91, 'parent_id' => null, 'name' => 'Account Transfer', 'code' => 'ACCOUNT_TRANSFER', 'description' => 'Transfers between accounts', 'icon' => 'fas fa-exchange-alt', 'color' => '#6c757d'],
-           ];
+            ['id' => 112, 'parent_id' => 91, 'name' => 'Transfer Incoming', 'code' => 'TRANSFER_INCOMING', 'description' => null, 'icon' => 'fas fa-exchange-alt', 'color' => '#6c757d'],
+            ['id' => 113, 'parent_id' => 91, 'name' => 'Transfer Outgoing', 'code' => 'TRANSFER_OUTGOING', 'description' => null, 'icon' => 'fas fa-exchange-alt', 'color' => '#6c757d'],
+        ];
 
         DB::table('categories')->insert($categories);
     }

--- a/resources/js/Pages/Statements/Review.jsx
+++ b/resources/js/Pages/Statements/Review.jsx
@@ -292,7 +292,7 @@ export default function Review({
         () =>
             categories.filter((c) => {
                 const code = String(c.code ?? '').toUpperCase();
-                return code !== 'INCOME' && code !== 'ACCOUNTTR';
+                return code !== 'INCOME' && code !== 'ACCOUNT_TRANSFER';
             }),
         [categories],
     );

--- a/resources/js/Pages/Transactions/Create.jsx
+++ b/resources/js/Pages/Transactions/Create.jsx
@@ -59,12 +59,13 @@ export default function Create({ categories, accounts }) {
     const parentCategories = categories.filter(cat => cat.parent_id === null);
 
     // Get income category
-    const incomeCategory = parentCategories.find(cat => cat.code === 'INCOME');
+    const incomeCategory = parentCategories.find(cat => String(cat.code).toUpperCase() === 'INCOME');
 
     // Get expense categories (excluding income and account transfer)
-    const expenseCategories = parentCategories.filter(cat =>
-        cat.code !== 'INCOME' && cat.code !== 'ACCOUNTTR'
-    );
+    const expenseCategories = parentCategories.filter(cat => {
+        const code = String(cat.code).toUpperCase();
+        return code !== 'INCOME' && code !== 'ACCOUNT_TRANSFER';
+    });
 
     // Function to get subcategories for a parent category
     const getSubcategories = (parentCategoryId) => {

--- a/resources/js/Pages/Transactions/Edit.jsx
+++ b/resources/js/Pages/Transactions/Edit.jsx
@@ -30,6 +30,7 @@ const toTimeInputValue = (value) => {
 };
 
 export default function Edit({ transaction, categories, accounts }) {
+    const isGroupedTransfer = transaction.transaction_type === 'transfer' && Boolean(transaction.transfer_group_id);
     const [selectedCategory, setSelectedCategory] = useState('');
     const [subcategories, setSubcategories] = useState([]);
     const [transactionType, setTransactionType] = useState(transaction.transaction_type || 'expense');
@@ -40,7 +41,7 @@ export default function Edit({ transaction, categories, accounts }) {
         transaction_time: toTimeInputValue(transaction.transaction_time),
         amount: transaction.amount || '',
         account_id: transaction.account_id || '',
-        transfer_to_account_id: '',
+        transfer_to_account_id: transaction.transfer_to_account_id || '',
         payment_method: transaction.payment_method || '',
         description: transaction.description || '',
         category_id: transaction.category_id || '',
@@ -68,15 +69,13 @@ export default function Edit({ transaction, categories, accounts }) {
     const parentCategories = categories.filter(cat => cat.parent_id === null);
 
     // Get income category
-    const incomeCategory = parentCategories.find(cat => cat.code === 'INCOME');
-
-    // Get account transfer category
-    const accountTransferCategory = parentCategories.find(cat => cat.code === 'ACCOUNTTR');
+    const incomeCategory = parentCategories.find(cat => String(cat.code).toUpperCase() === 'INCOME');
 
     // Get expense categories (excluding income and account transfer)
-    const expenseCategories = parentCategories.filter(cat =>
-        cat.code !== 'INCOME' && cat.code !== 'ACCOUNTTR'
-    );
+    const expenseCategories = parentCategories.filter(cat => {
+        const code = String(cat.code).toUpperCase();
+        return code !== 'INCOME' && code !== 'ACCOUNT_TRANSFER';
+    });
 
     // Function to get subcategories for a parent category
     const getSubcategories = (parentCategoryId) => {
@@ -304,6 +303,7 @@ export default function Edit({ transaction, categories, accounts }) {
                                             value="income"
                                             checked={transactionType === 'income'}
                                             onChange={() => handleTransactionTypeChange('income')}
+                                            disabled={isGroupedTransfer}
                                         />
                                         <label className="btn btn-outline-success" htmlFor="type_income">
                                             <i className="fas fa-arrow-down me-2"></i>Income
@@ -317,6 +317,7 @@ export default function Edit({ transaction, categories, accounts }) {
                                             value="expense"
                                             checked={transactionType === 'expense'}
                                             onChange={() => handleTransactionTypeChange('expense')}
+                                            disabled={isGroupedTransfer}
                                         />
                                         <label className="btn btn-outline-danger" htmlFor="type_expense">
                                             <i className="fas fa-arrow-up me-2"></i>Expense
@@ -330,6 +331,7 @@ export default function Edit({ transaction, categories, accounts }) {
                                             value="transfer"
                                             checked={transactionType === 'transfer'}
                                             onChange={() => handleTransactionTypeChange('transfer')}
+                                            disabled={isGroupedTransfer}
                                         />
                                         <label className="btn btn-outline-primary" htmlFor="type_transfer">
                                             <i className="fas fa-exchange-alt me-2"></i>Account Transfer

--- a/resources/js/Pages/Transactions/Index.jsx
+++ b/resources/js/Pages/Transactions/Index.jsx
@@ -10,6 +10,10 @@ export default function Index({ transactions = {}, categories = [], accounts = [
     const [selectedCategory, setSelectedCategory] = useState(filters.category || '');
     const [subcategories, setSubcategories] = useState([]);
 
+    const isIncoming = (transaction) =>
+        transaction.transaction_type === 'income'
+        || transaction.category?.code === 'TRANSFER_INCOMING';
+
     // Function to get color class based on amount value
     const getAmountColorClass = (amount, transactionType) => {
         const value = parseFloat(amount || 0);
@@ -538,14 +542,18 @@ export default function Index({ transactions = {}, categories = [], accounts = [
                                                     <td>{new Date(transaction.transaction_date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</td>
                                                     <td>{transaction.description}</td>
                                                     <td>
-                                                        <span className={`badge ${transaction.transaction_type === 'income' ? 'bg-success' : 'bg-danger'}`}>
+                                                        <span className={`badge ${
+                                                            transaction.transaction_type === 'transfer'
+                                                                ? 'bg-info text-dark'
+                                                                : transaction.transaction_type === 'income' ? 'bg-success' : 'bg-danger'
+                                                        }`}>
                                                             {transaction.category?.name || 'N/A'}
                                                         </span>
                                                     </td>
                                                     <td>{transaction.account?.name || 'N/A'}</td>
                                                     <td>
                                                         <span className={`fw-bold ${getAmountColorClass(transaction.amount, transaction.transaction_type)}`}>
-                                                            {transaction.transaction_type === 'income' ? '+' : '-'}₹{parseFloat(transaction.amount || 0).toFixed(2)}
+                                                            {isIncoming(transaction) ? '+' : '-'}₹{parseFloat(transaction.amount || 0).toFixed(2)}
                                                         </span>
                                                     </td>
                                                     <td>

--- a/resources/js/Pages/Transactions/Show.jsx
+++ b/resources/js/Pages/Transactions/Show.jsx
@@ -4,6 +4,9 @@ import BootstrapLayout from '../../Layouts/BootstrapLayout';
 
 export default function Show({ transaction }) {
 
+    const isIncoming = transaction.transaction_type === 'income'
+        || transaction.category?.code === 'TRANSFER_INCOMING';
+
     const formatCurrency = (amount) => {
         return new Intl.NumberFormat('en-IN', {
             style: 'currency',
@@ -85,11 +88,11 @@ export default function Show({ transaction }) {
                                             <label className="form-label text-muted">Amount</label>
                                             <div>
                                                 <h4 className={`mb-0 ${
-                                                    transaction.transaction_type === 'expense' || transaction.amount < 0
+                                                    !isIncoming
                                                         ? 'text-danger'
                                                         : 'text-success'
                                                 }`}>
-                                                    {formatCurrency(Math.abs(transaction.amount))}
+                                                    {isIncoming ? '+' : '-'}{formatCurrency(Math.abs(transaction.amount))}
                                                 </h4>
                                             </div>
                                         </div>

--- a/resources/js/Pages/Welcome.jsx
+++ b/resources/js/Pages/Welcome.jsx
@@ -427,11 +427,15 @@ export default function Welcome({ stats, recentTransactions }) {
                                                         </td>
                                                         <td>
                                                             <span className={`fw-bold ${
-                                                                transaction.transaction_type === 'expense' || transaction.amount < 0
+                                                                transaction.transaction_type === 'expense'
+                                                                    || transaction.category?.code === 'TRANSFER_OUTGOING'
+                                                                    || transaction.amount < 0
                                                                     ? 'text-danger'
                                                                     : 'text-success'
                                                             }`}>
-                                                                {transaction.transaction_type === 'expense' || transaction.amount < 0 ? '-' : '+'}
+                                                                {transaction.transaction_type === 'expense'
+                                                                    || transaction.category?.code === 'TRANSFER_OUTGOING'
+                                                                    || transaction.amount < 0 ? '-' : '+'}
                                                                 ₹{Math.abs(transaction.amount).toFixed(2)}
                                                             </span>
                                                         </td>

--- a/tests/Feature/AccountTransferSchemaTest.php
+++ b/tests/Feature/AccountTransferSchemaTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use Database\Seeders\CategorySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class AccountTransferSchemaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_category_seeder_creates_one_transfer_root_with_incoming_and_outgoing_children(): void
+    {
+        $this->seed(CategorySeeder::class);
+
+        $roots = DB::table('categories')
+            ->whereNull('parent_id')
+            ->whereRaw('LOWER(code) = ?', ['account_transfer'])
+            ->get();
+
+        $this->assertCount(1, $roots);
+        $this->assertSame(
+            1,
+            DB::table('categories')->whereRaw('LOWER(code) = ?', ['account_transfer'])->count()
+        );
+        $this->assertEqualsCanonicalizing(
+            ['TRANSFER_INCOMING', 'TRANSFER_OUTGOING'],
+            DB::table('categories')
+                ->where('parent_id', $roots->first()->id)
+                ->pluck('code')
+                ->all()
+        );
+    }
+
+    public function test_transactions_table_has_nullable_transfer_group_id(): void
+    {
+        $this->assertTrue(Schema::hasColumn('transactions', 'transfer_group_id'));
+
+        $column = collect(Schema::getColumns('transactions'))->firstWhere('name', 'transfer_group_id');
+
+        $this->assertTrue($column['nullable']);
+    }
+}

--- a/tests/Feature/AccountTransferTest.php
+++ b/tests/Feature/AccountTransferTest.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Services\AccountTransferService;
+use Database\Seeders\CategorySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Inertia\Testing\AssertableInertia;
+use RuntimeException;
+use Tests\TestCase;
+
+class AccountTransferTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_moves_balance_and_creates_two_linked_transfer_legs(): void
+    {
+        $this->seed(CategorySeeder::class);
+        $source = Account::factory()->create(['opening_balance' => 10000, 'current_balance' => 10000]);
+        $destination = Account::factory()->create(['opening_balance' => 1000, 'current_balance' => 1000]);
+
+        app(AccountTransferService::class)->create([
+            'account_id' => $source->id,
+            'transfer_to_account_id' => $destination->id,
+            'amount' => 500,
+            'description' => 'Move savings',
+            'transaction_date' => '2026-07-18',
+            'transaction_time' => '10:30',
+        ]);
+
+        $legs = Transaction::orderBy('id')->get();
+
+        $this->assertCount(2, $legs);
+        $this->assertSame('transfer', $legs[0]->transaction_type);
+        $this->assertSame('TRANSFER_OUTGOING', $legs[0]->category->code);
+        $this->assertSame('transfer', $legs[1]->transaction_type);
+        $this->assertSame('TRANSFER_INCOMING', $legs[1]->category->code);
+        $this->assertNotNull($legs[0]->transfer_group_id);
+        $this->assertSame($legs[0]->transfer_group_id, $legs[1]->transfer_group_id);
+        $this->assertSame('9500.00', $source->fresh()->current_balance);
+        $this->assertSame('1500.00', $destination->fresh()->current_balance);
+    }
+
+    public function test_update_changes_both_legs_and_balances(): void
+    {
+        $this->seed(CategorySeeder::class);
+        $source = Account::factory()->create(['opening_balance' => 10000, 'current_balance' => 10000]);
+        $destination = Account::factory()->create(['opening_balance' => 1000, 'current_balance' => 1000]);
+        $service = app(AccountTransferService::class);
+        [$outgoing] = $service->create($this->transferData($source, $destination, 500));
+
+        $service->update($outgoing, $this->transferData($source, $destination, 750));
+
+        $legs = Transaction::where('transfer_group_id', $outgoing->transfer_group_id)->get();
+        $this->assertCount(2, $legs);
+        $this->assertTrue($legs->every(fn (Transaction $leg) => $leg->amount === '750.00'));
+        $this->assertSame('9250.00', $source->fresh()->current_balance);
+        $this->assertSame('1750.00', $destination->fresh()->current_balance);
+    }
+
+    public function test_update_can_move_both_legs_to_different_accounts(): void
+    {
+        $this->seed(CategorySeeder::class);
+        $oldSource = Account::factory()->create(['opening_balance' => 10000, 'current_balance' => 10000]);
+        $oldDestination = Account::factory()->create(['opening_balance' => 1000, 'current_balance' => 1000]);
+        $newSource = Account::factory()->create(['opening_balance' => 8000, 'current_balance' => 8000]);
+        $newDestination = Account::factory()->create(['opening_balance' => 2000, 'current_balance' => 2000]);
+        $service = app(AccountTransferService::class);
+        [$outgoing] = $service->create($this->transferData($oldSource, $oldDestination, 500));
+
+        $service->update($outgoing, $this->transferData($newSource, $newDestination, 750));
+
+        $this->assertSame('10000.00', $oldSource->fresh()->current_balance);
+        $this->assertSame('1000.00', $oldDestination->fresh()->current_balance);
+        $this->assertSame('7250.00', $newSource->fresh()->current_balance);
+        $this->assertSame('2750.00', $newDestination->fresh()->current_balance);
+    }
+
+    public function test_delete_removes_both_legs_and_restores_balances(): void
+    {
+        $this->seed(CategorySeeder::class);
+        $source = Account::factory()->create(['opening_balance' => 10000, 'current_balance' => 10000]);
+        $destination = Account::factory()->create(['opening_balance' => 1000, 'current_balance' => 1000]);
+        $service = app(AccountTransferService::class);
+        [$outgoing] = $service->create($this->transferData($source, $destination, 500));
+
+        $service->delete($outgoing);
+
+        $this->assertDatabaseCount('transactions', 0);
+        $this->assertSame('10000.00', $source->fresh()->current_balance);
+        $this->assertSame('1000.00', $destination->fresh()->current_balance);
+    }
+
+    public function test_recalculate_balance_understands_transfer_direction(): void
+    {
+        $this->seed(CategorySeeder::class);
+        $source = Account::factory()->create(['opening_balance' => 10000, 'current_balance' => 10000]);
+        $destination = Account::factory()->create(['opening_balance' => 1000, 'current_balance' => 1000]);
+        app(AccountTransferService::class)->create($this->transferData($source, $destination, 500));
+
+        $source->update(['current_balance' => 0]);
+        $destination->update(['current_balance' => 0]);
+
+        $this->assertSame(9500.0, $source->recalculateBalance());
+        $this->assertSame(1500.0, $destination->recalculateBalance());
+    }
+
+    public function test_store_creates_transfer_without_payment_method(): void
+    {
+        $this->seed(CategorySeeder::class);
+        $source = Account::factory()->create(['opening_balance' => 10000, 'current_balance' => 10000]);
+        $destination = Account::factory()->create(['opening_balance' => 1000, 'current_balance' => 1000]);
+
+        $response = $this->post(route('transactions.store'), array_merge(
+            $this->transferData($source, $destination, 500),
+            ['transaction_type' => Transaction::TYPE_TRANSFER]
+        ));
+
+        $response->assertRedirect(route('transactions.index'))->assertSessionHasNoErrors();
+        $this->assertDatabaseCount('transactions', 2);
+        $this->assertSame('9500.00', $source->fresh()->current_balance);
+        $this->assertSame('1500.00', $destination->fresh()->current_balance);
+    }
+
+    public function test_store_rejects_same_source_and_destination_account(): void
+    {
+        $this->seed(CategorySeeder::class);
+        $account = Account::factory()->create();
+
+        $response = $this->from(route('transactions.create'))->post(route('transactions.store'), array_merge(
+            $this->transferData($account, $account, 500),
+            ['transaction_type' => Transaction::TYPE_TRANSFER]
+        ));
+
+        $response->assertRedirect(route('transactions.create'))
+            ->assertSessionHasErrors('transfer_to_account_id');
+        $this->assertDatabaseCount('transactions', 0);
+    }
+
+    public function test_edit_prefills_destination_from_either_transfer_leg(): void
+    {
+        $this->seed(CategorySeeder::class);
+        $source = Account::factory()->create();
+        $destination = Account::factory()->create();
+        [$outgoing, $incoming] = app(AccountTransferService::class)->create(
+            $this->transferData($source, $destination, 500)
+        );
+
+        $this->get(route('transactions.edit', $outgoing))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('transaction.account_id', $source->id)
+                ->where('transaction.transfer_to_account_id', $destination->id)
+            );
+
+        $this->get(route('transactions.edit', $incoming))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('transaction.account_id', $source->id)
+                ->where('transaction.transfer_to_account_id', $destination->id)
+            );
+    }
+
+    public function test_update_and_destroy_routes_mutate_the_complete_transfer(): void
+    {
+        $this->seed(CategorySeeder::class);
+        $source = Account::factory()->create(['opening_balance' => 10000, 'current_balance' => 10000]);
+        $destination = Account::factory()->create(['opening_balance' => 1000, 'current_balance' => 1000]);
+        [$outgoing] = app(AccountTransferService::class)->create($this->transferData($source, $destination, 500));
+
+        $this->put(route('transactions.update', $outgoing), array_merge(
+            $this->transferData($source, $destination, 750),
+            [
+                'transaction_type' => Transaction::TYPE_TRANSFER,
+                'expensed_date' => '2026-07-18',
+            ]
+        ))->assertRedirect(route('transactions.index'))->assertSessionHasNoErrors();
+
+        $this->assertSame(2, Transaction::where('transfer_group_id', $outgoing->transfer_group_id)->count());
+        $this->assertSame('9250.00', $source->fresh()->current_balance);
+        $this->assertSame('1750.00', $destination->fresh()->current_balance);
+
+        $this->delete(route('transactions.destroy', $outgoing))
+            ->assertRedirect(route('transactions.index'));
+
+        $this->assertDatabaseCount('transactions', 0);
+        $this->assertSame('10000.00', $source->fresh()->current_balance);
+        $this->assertSame('1000.00', $destination->fresh()->current_balance);
+    }
+
+    public function test_second_leg_failure_rolls_back_first_leg_and_balance_change(): void
+    {
+        $this->seed(CategorySeeder::class);
+        $source = Account::factory()->create(['opening_balance' => 10000, 'current_balance' => 10000]);
+        $destination = Account::factory()->create(['opening_balance' => 1000, 'current_balance' => 1000]);
+        $incomingCategoryId = Category::where('code', Transaction::CATEGORY_TRANSFER_INCOMING)->value('id');
+        $eventName = 'eloquent.creating: '.Transaction::class;
+
+        Event::listen($eventName, function (Transaction $transaction) use ($incomingCategoryId) {
+            if ($transaction->category_id === $incomingCategoryId) {
+                throw new RuntimeException('Forced incoming leg failure.');
+            }
+        });
+
+        try {
+            app(AccountTransferService::class)->create($this->transferData($source, $destination, 500));
+            $this->fail('The forced incoming leg failure was not raised.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Forced incoming leg failure.', $exception->getMessage());
+        } finally {
+            Event::forget($eventName);
+        }
+
+        $this->assertDatabaseCount('transactions', 0);
+        $this->assertSame('10000.00', $source->fresh()->current_balance);
+        $this->assertSame('1000.00', $destination->fresh()->current_balance);
+    }
+
+    public function test_bulk_destroy_deletes_each_selected_transfer_group_once(): void
+    {
+        $this->seed(CategorySeeder::class);
+        $source = Account::factory()->create(['opening_balance' => 10000, 'current_balance' => 10000]);
+        $destination = Account::factory()->create(['opening_balance' => 1000, 'current_balance' => 1000]);
+        [$outgoing, $incoming] = app(AccountTransferService::class)->create(
+            $this->transferData($source, $destination, 500)
+        );
+
+        $this->post(route('transactions.bulk-destroy'), ['ids' => [$outgoing->id, $incoming->id]])
+            ->assertRedirect(route('transactions.index'));
+
+        $this->assertDatabaseCount('transactions', 0);
+        $this->assertSame('10000.00', $source->fresh()->current_balance);
+        $this->assertSame('1000.00', $destination->fresh()->current_balance);
+    }
+
+    public function test_store_redirect_uses_the_current_request_origin(): void
+    {
+        $this->seed(CategorySeeder::class);
+        $source = Account::factory()->create();
+        $destination = Account::factory()->create();
+
+        $response = $this->post('http://127.0.0.1:8001/transactions', array_merge(
+            $this->transferData($source, $destination, 500),
+            ['transaction_type' => Transaction::TYPE_TRANSFER]
+        ));
+
+        $response->assertHeader('Location', 'http://127.0.0.1:8001/transactions');
+    }
+
+    private function transferData(Account $source, Account $destination, int $amount): array
+    {
+        return [
+            'account_id' => $source->id,
+            'transfer_to_account_id' => $destination->id,
+            'amount' => $amount,
+            'description' => 'Move savings',
+            'transaction_date' => '2026-07-18',
+            'transaction_time' => '10:30',
+        ];
+    }
+}

--- a/tests/Feature/TransferReportingTest.php
+++ b/tests/Feature/TransferReportingTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Services\AccountTransferService;
+use Database\Seeders\CategorySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class TransferReportingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_transfer_does_not_change_income_expense_or_net_totals(): void
+    {
+        $this->seed(CategorySeeder::class);
+        $source = Account::factory()->create(['opening_balance' => 10000, 'current_balance' => 10000]);
+        $destination = Account::factory()->create(['opening_balance' => 1000, 'current_balance' => 1000]);
+
+        Transaction::create([
+            'account_id' => $source->id,
+            'category_id' => Category::where('code', 'salary')->value('id'),
+            'transaction_type' => Transaction::TYPE_INCOME,
+            'amount' => 2000,
+            'transaction_date' => '2026-07-18',
+            'payment_method' => 'Bank Transfer',
+        ]);
+        Transaction::create([
+            'account_id' => $source->id,
+            'category_id' => Category::where('code', 'groceries')->value('id'),
+            'transaction_type' => Transaction::TYPE_EXPENSE,
+            'amount' => 300,
+            'transaction_date' => '2026-07-18',
+            'payment_method' => 'UPI',
+        ]);
+        app(AccountTransferService::class)->create([
+            'account_id' => $source->id,
+            'transfer_to_account_id' => $destination->id,
+            'amount' => 500,
+            'transaction_date' => '2026-07-18',
+        ]);
+
+        $this->get(route('transactions.index'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('totals.total_income', 2000)
+                ->where('totals.total_expenses', 300)
+                ->where('totals.net_balance', 1700)
+            );
+
+        $this->get('/')
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('stats.totalIncome', 2000)
+                ->where('stats.totalExpenses', 300)
+                ->where('stats.netBalance', 1700)
+            );
+
+        $this->getJson(route('api.stats.dashboard'))
+            ->assertOk()
+            ->assertJsonPath('overall.total_income', 2000)
+            ->assertJsonPath('overall.total_expense', 300)
+            ->assertJsonPath('overall.net_balance', 1700);
+    }
+
+    public function test_csv_maps_incoming_transfer_to_credit_and_outgoing_to_debit(): void
+    {
+        $this->seed(CategorySeeder::class);
+        $source = Account::factory()->create();
+        $destination = Account::factory()->create();
+        app(AccountTransferService::class)->create([
+            'account_id' => $source->id,
+            'transfer_to_account_id' => $destination->id,
+            'amount' => 500,
+            'transaction_date' => '2026-07-18',
+        ]);
+
+        $content = $this->get(route('transactions.export'))->streamedContent();
+        $rows = array_map('str_getcsv', preg_split('/\r\n|\r|\n/', trim($content)));
+
+        $this->assertSame('500.00', $rows[1][5]);
+        $this->assertSame('', $rows[1][6]);
+        $this->assertSame('', $rows[2][5]);
+        $this->assertSame('500.00', $rows[2][6]);
+    }
+}


### PR DESCRIPTION
## Summary
- represent internal account transfers as two linked directional ledger rows
- make transfer creation, updates, and deletion atomic
- keep account balances correct while excluding transfers from income, expense, and net-income totals
- update transaction forms and displays for transfer semantics
- fix request-origin redirects so transfer success feedback appears immediately
- add schema, lifecycle, balance, reporting, and redirect regression coverage

## Verification
- `php artisan test` — 75 tests passed, 421 assertions
- `npm run build` — passed
- PHP lint — passed
- `git diff --check` — passed
- manually verified transfer create/update/delete, balances, reporting, redirect, and success notification

Fixes #56