### PR TITLE
fix: repair broken dashboard and transaction API routes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -44,7 +44,6 @@ Route::get('api/categories/with-totals', [CategoryController::class, 'getCategor
 Route::get('transactions/export', [TransactionController::class, 'export'])->name('transactions.export');
 Route::resource('transactions', TransactionController::class);
 Route::post('transactions/bulk-destroy', [TransactionController::class, 'bulkDestroy'])->name('transactions.bulk-destroy');
-Route::get('api/transactions', [TransactionController::class, 'getTransactions'])->name('api.transactions');
 
 // Budget routes
 Route::resource('budgets', BudgetController::class);
@@ -52,7 +51,7 @@ Route::patch('budgets/{budget}/toggle-status', [BudgetController::class, 'toggle
 Route::get('api/budgets/summary', [BudgetController::class, 'getSummary'])->name('api.budgets.summary');
 
 // Dashboard routes
-Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard.index');
+Route::redirect('/dashboard', '/')->name('dashboard.index');
 Route::get('/dashboard/analytics', [DashboardController::class, 'analytics'])->name('dashboard.analytics');
 
 // API Routes for Statistics (useful for mobile apps)

--- a/tests/Feature/BrokenApplicationRoutesTest.php
+++ b/tests/Feature/BrokenApplicationRoutesTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BrokenApplicationRoutesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_removed_transactions_api_returns_not_found(): void
+    {
+        $this->getJson('/api/transactions')->assertNotFound();
+    }
+
+    public function test_dashboard_redirects_to_homepage(): void
+    {
+        $this->get('/dashboard')->assertRedirect('/');
+    }
+
+    public function test_dashboard_analytics_remains_available(): void
+    {
+        $this->get('/dashboard/analytics')->assertOk();
+    }
+}


### PR DESCRIPTION
## Summary
- remove the stale `/api/transactions` route that called a missing controller method
- preserve `/dashboard` bookmarks by redirecting them to the working homepage
- keep `/dashboard/analytics` available and cover all three route decisions with feature tests

## Test plan
- `php artisan test tests/Feature/BrokenApplicationRoutesTest.php`
- `composer test`
- `npm run build`
- `./vendor/bin/pint --test routes/web.php tests/Feature/BrokenApplicationRoutesTest.php`

## Notes
- The full Pint check still reports pre-existing violations tracked separately in Issue #68.
- The PHP suite passes with the existing PDO deprecation notices tracked by Issue #68.

Closes #59