### PR TITLE
chore: clean Pint violations and PDO deprecations

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -39,6 +39,9 @@ jobs:
     - name: Install PHP dependencies
       run: composer install --no-ansi --no-interaction --no-progress --prefer-dist
 
+    - name: Check PHP formatting
+      run: ./vendor/bin/pint --test
+
     - name: Install frontend dependencies
       run: npm install --no-audit --no-fund
 

--- a/app/AI/Tools/CreateTransactionTool.php
+++ b/app/AI/Tools/CreateTransactionTool.php
@@ -2,11 +2,11 @@
 
 namespace App\AI\Tools;
 
-use Prism\Prism\Tool;
-use App\Models\Transaction;
 use App\Models\Account;
 use App\Models\Category;
+use App\Models\Transaction;
 use Carbon\Carbon;
+use Prism\Prism\Tool;
 
 class CreateTransactionTool extends Tool
 {
@@ -40,14 +40,14 @@ class CreateTransactionTool extends Tool
                     ->where('is_active', true)
                     ->first();
             }
-            if (!$account) {
+            if (! $account) {
                 $account = Account::where('is_active', true)->first();
             }
 
-            if (!$account) {
+            if (! $account) {
                 return json_encode([
                     'success' => false,
-                    'error'   => 'No active account found. Please create an account first.',
+                    'error' => 'No active account found. Please create an account first.',
                 ]);
             }
 
@@ -56,55 +56,55 @@ class CreateTransactionTool extends Tool
                 ->whereNotNull('parent_id')
                 ->first();
 
-            if (!$category) {
+            if (! $category) {
                 $category = Category::where('name', 'Other')
                     ->whereNotNull('parent_id')
                     ->first();
             }
 
-            if (!$category) {
+            if (! $category) {
                 $category = Category::whereNotNull('parent_id')->first();
             }
 
-            if (!$category) {
+            if (! $category) {
                 return json_encode([
                     'success' => false,
-                    'error'   => 'No categories found. Please set up expense categories first.',
+                    'error' => 'No categories found. Please set up expense categories first.',
                 ]);
             }
 
             // Validate transaction type
-            if (!in_array($transaction_type, ['income', 'expense', 'transfer'])) {
+            if (! in_array($transaction_type, ['income', 'expense', 'transfer'])) {
                 return json_encode([
                     'success' => false,
-                    'error'   => 'Invalid transaction type. Must be "income" or "expense".',
+                    'error' => 'Invalid transaction type. Must be "income" or "expense".',
                 ]);
             }
 
             // Create transaction
             $transaction = Transaction::create([
-                'account_id'       => $account->id,
-                'category_id'      => $category->id,
+                'account_id' => $account->id,
+                'category_id' => $category->id,
                 'transaction_type' => $transaction_type,
-                'amount'           => abs($amount),
-                'description'      => $description,
+                'amount' => abs($amount),
+                'description' => $description,
                 'transaction_date' => $date ? Carbon::createFromFormat('Y-m-d', $date)->toDateString() : Carbon::today()->toDateString(),
-                'payment_method'   => 'Other',
+                'payment_method' => 'Other',
             ]);
 
             return json_encode([
-                'success'    => true,
-                'id'         => $transaction->id,
-                'message'    => "✅ Created {$transaction_type} of ₹{$amount} for \"{$description}\"",
-                'account'    => $account->name,
-                'category'   => $category->name,
-                'date'       => $transaction->transaction_date->format('Y-m-d'),
+                'success' => true,
+                'id' => $transaction->id,
+                'message' => "✅ Created {$transaction_type} of ₹{$amount} for \"{$description}\"",
+                'account' => $account->name,
+                'category' => $category->name,
+                'date' => $transaction->transaction_date->format('Y-m-d'),
             ]);
 
         } catch (\Throwable $e) {
             return json_encode([
                 'success' => false,
-                'error'   => 'Failed to create transaction: ' . $e->getMessage(),
+                'error' => 'Failed to create transaction: '.$e->getMessage(),
             ]);
         }
     }

--- a/app/AI/Tools/GetAccountBalancesTool.php
+++ b/app/AI/Tools/GetAccountBalancesTool.php
@@ -21,8 +21,8 @@ class GetAccountBalancesTool extends Tool
         try {
             $query = Account::where('is_active', true)->orderBy('name');
 
-            if (!empty($account_name)) {
-                $query->where('name', 'like', '%' . $account_name . '%');
+            if (! empty($account_name)) {
+                $query->where('name', 'like', '%'.$account_name.'%');
             }
 
             $accounts = $query->get();
@@ -30,23 +30,23 @@ class GetAccountBalancesTool extends Tool
             if ($accounts->isEmpty()) {
                 return json_encode([
                     'success' => false,
-                    'error'   => 'No active accounts found' . ($account_name ? " matching \"{$account_name}\"" : '') . '.',
+                    'error' => 'No active accounts found'.($account_name ? " matching \"{$account_name}\"" : '').'.',
                 ]);
             }
 
             $totalLiquid = 0;
             $result = $accounts->map(function (Account $acc) use (&$totalLiquid) {
                 $row = [
-                    'name'            => $acc->name,
-                    'type'            => $acc->getTypeLabel(),
-                    'bank_name'       => $acc->bank_name,
+                    'name' => $acc->name,
+                    'type' => $acc->getTypeLabel(),
+                    'bank_name' => $acc->bank_name,
                     'current_balance' => (float) $acc->current_balance,
                 ];
 
                 if ($acc->isCreditCard()) {
                     $used = max(0, -1 * (float) $acc->current_balance); // balance goes negative as credit is used
-                    $row['credit_limit']     = (float) $acc->credit_limit;
-                    $row['credit_used']      = $used;
+                    $row['credit_limit'] = (float) $acc->credit_limit;
+                    $row['credit_used'] = $used;
                     $row['credit_available'] = max(0, (float) $acc->credit_limit - $used);
                 } else {
                     $totalLiquid += (float) $acc->current_balance;
@@ -56,16 +56,16 @@ class GetAccountBalancesTool extends Tool
             })->values()->all();
 
             return json_encode([
-                'success'             => true,
-                'accounts'            => $result,
-                'total_liquid_balance'=> round($totalLiquid, 2),
-                'account_count'       => count($result),
+                'success' => true,
+                'accounts' => $result,
+                'total_liquid_balance' => round($totalLiquid, 2),
+                'account_count' => count($result),
             ]);
 
         } catch (\Throwable $e) {
             return json_encode([
                 'success' => false,
-                'error'   => 'Failed to fetch balances: ' . $e->getMessage(),
+                'error' => 'Failed to fetch balances: '.$e->getMessage(),
             ]);
         }
     }

--- a/app/AI/Tools/GetSpendingInsightsTool.php
+++ b/app/AI/Tools/GetSpendingInsightsTool.php
@@ -3,7 +3,6 @@
 namespace App\AI\Tools;
 
 use App\Models\Budget;
-use App\Models\Category;
 use App\Models\Transaction;
 use Carbon\Carbon;
 use Prism\Prism\Tool;
@@ -15,11 +14,11 @@ class GetSpendingInsightsTool extends Tool
         $this
             ->as('get_spending_insights')
             ->for(
-                'Analyse financial data. Use query_type to choose what to retrieve: ' .
-                '"spending_summary" for income/expense overview, ' .
-                '"budget_status" to check budgets (over/under), ' .
-                '"payment_breakdown" to see UPI vs cash vs card totals, ' .
-                '"tag_summary" to see spending by tag, ' .
+                'Analyse financial data. Use query_type to choose what to retrieve: '.
+                '"spending_summary" for income/expense overview, '.
+                '"budget_status" to check budgets (over/under), '.
+                '"payment_breakdown" to see UPI vs cash vs card totals, '.
+                '"tag_summary" to see spending by tag, '.
                 '"day_breakdown" to find the busiest spending day of the week.'
             )
             ->withEnumParameter(
@@ -42,23 +41,23 @@ class GetSpendingInsightsTool extends Tool
     }
 
     public function execute(
-        string  $query_type,
-        ?string $period       = 'this_month',
+        string $query_type,
+        ?string $period = 'this_month',
         ?string $category_name = null,
     ): string {
         try {
             return match ($query_type) {
-                'spending_summary'   => $this->spendingSummary($period ?? 'this_month'),
-                'budget_status'      => $this->budgetStatus($category_name),
-                'payment_breakdown'  => $this->paymentBreakdown($period ?? 'this_month'),
-                'tag_summary'        => $this->tagSummary($period ?? 'all'),
-                'day_breakdown'      => $this->dayBreakdown($period ?? 'this_month'),
-                default              => json_encode(['success' => false, 'error' => 'Unknown query_type.']),
+                'spending_summary' => $this->spendingSummary($period ?? 'this_month'),
+                'budget_status' => $this->budgetStatus($category_name),
+                'payment_breakdown' => $this->paymentBreakdown($period ?? 'this_month'),
+                'tag_summary' => $this->tagSummary($period ?? 'all'),
+                'day_breakdown' => $this->dayBreakdown($period ?? 'this_month'),
+                default => json_encode(['success' => false, 'error' => 'Unknown query_type.']),
             };
         } catch (\Throwable $e) {
             return json_encode([
                 'success' => false,
-                'error'   => 'Insight query failed: ' . $e->getMessage(),
+                'error' => 'Insight query failed: '.$e->getMessage(),
             ]);
         }
     }
@@ -68,8 +67,8 @@ class GetSpendingInsightsTool extends Tool
     private function applyPeriod($query, string $period)
     {
         match ($period) {
-            'today'      => $query->whereDate('transaction_date', Carbon::today()),
-            'this_week'  => $query->whereBetween('transaction_date', [
+            'today' => $query->whereDate('transaction_date', Carbon::today()),
+            'this_week' => $query->whereBetween('transaction_date', [
                 Carbon::now()->startOfWeek(),
                 Carbon::now()->endOfWeek(),
             ]),
@@ -77,7 +76,7 @@ class GetSpendingInsightsTool extends Tool
                 ->whereMonth('transaction_date', Carbon::now()->month),
             'last_month' => $query->whereYear('transaction_date', Carbon::now()->subMonth()->year)
                 ->whereMonth('transaction_date', Carbon::now()->subMonth()->month),
-            default      => null, // 'all' — no filter
+            default => null, // 'all' — no filter
         };
 
         return $query;
@@ -87,9 +86,9 @@ class GetSpendingInsightsTool extends Tool
     {
         $base = $this->applyPeriod(Transaction::query(), $period);
 
-        $income  = (clone $base)->where('transaction_type', 'income')->sum('amount');
+        $income = (clone $base)->where('transaction_type', 'income')->sum('amount');
         $expense = (clone $base)->where('transaction_type', 'expense')->sum('amount');
-        $net     = $income - $expense;
+        $net = $income - $expense;
         $savings = $income > 0 ? round(($net / $income) * 100, 1) : 0;
 
         $topCategories = (clone $base)
@@ -102,18 +101,18 @@ class GetSpendingInsightsTool extends Tool
             ->get()
             ->map(fn ($r) => [
                 'category' => $r->category?->name ?? 'Uncategorized',
-                'total'    => round((float) $r->total, 2),
-                'count'    => (int) $r->cnt,
+                'total' => round((float) $r->total, 2),
+                'count' => (int) $r->cnt,
             ])->values()->all();
 
         return json_encode([
-            'success'        => true,
-            'query_type'     => 'spending_summary',
-            'period'         => $period,
-            'income'         => round((float) $income, 2),
-            'expense'        => round((float) $expense, 2),
-            'net'            => round((float) $net, 2),
-            'savings_rate'   => $savings . '%',
+            'success' => true,
+            'query_type' => 'spending_summary',
+            'period' => $period,
+            'income' => round((float) $income, 2),
+            'expense' => round((float) $expense, 2),
+            'net' => round((float) $net, 2),
+            'savings_rate' => $savings.'%',
             'top_categories' => $topCategories,
         ]);
     }
@@ -124,9 +123,8 @@ class GetSpendingInsightsTool extends Tool
             ->active()
             ->current();
 
-        if (!empty($categoryName)) {
-            $query->whereHas('category', fn ($q) =>
-                $q->where('name', 'like', '%' . $categoryName . '%')
+        if (! empty($categoryName)) {
+            $query->whereHas('category', fn ($q) => $q->where('name', 'like', '%'.$categoryName.'%')
             );
         }
 
@@ -137,34 +135,34 @@ class GetSpendingInsightsTool extends Tool
                 'success' => true,
                 'query_type' => 'budget_status',
                 'budgets' => [],
-                'message' => 'No active budgets found' . ($categoryName ? " for \"{$categoryName}\"" : '') . '.',
+                'message' => 'No active budgets found'.($categoryName ? " for \"{$categoryName}\"" : '').'.',
             ]);
         }
 
         $result = $budgets->map(fn (Budget $b) => [
-            'name'           => $b->name,
-            'category'       => $b->category?->name,
-            'limit'          => round((float) $b->amount, 2),
-            'spent'          => round((float) $b->spent_amount, 2),
-            'remaining'      => round((float) $b->remaining_amount, 2),
-            'percent_used'   => $b->percentage_used . '%',
-            'status'         => $b->status, // success / warning / danger
-            'period_type'    => $b->period_type,
-            'start_date'     => $b->start_date->format('Y-m-d'),
-            'end_date'       => $b->end_date->format('Y-m-d'),
+            'name' => $b->name,
+            'category' => $b->category?->name,
+            'limit' => round((float) $b->amount, 2),
+            'spent' => round((float) $b->spent_amount, 2),
+            'remaining' => round((float) $b->remaining_amount, 2),
+            'percent_used' => $b->percentage_used.'%',
+            'status' => $b->status, // success / warning / danger
+            'period_type' => $b->period_type,
+            'start_date' => $b->start_date->format('Y-m-d'),
+            'end_date' => $b->end_date->format('Y-m-d'),
         ])->values()->all();
 
         $exceeded = collect($result)->where('status', 'danger')->count();
-        $warning  = collect($result)->where('status', 'warning')->count();
+        $warning = collect($result)->where('status', 'warning')->count();
 
         return json_encode([
-            'success'          => true,
-            'query_type'       => 'budget_status',
-            'total_budgets'    => count($result),
-            'exceeded'         => $exceeded,
-            'warning'          => $warning,
-            'on_track'         => count($result) - $exceeded - $warning,
-            'budgets'          => $result,
+            'success' => true,
+            'query_type' => 'budget_status',
+            'total_budgets' => count($result),
+            'exceeded' => $exceeded,
+            'warning' => $warning,
+            'on_track' => count($result) - $exceeded - $warning,
+            'budgets' => $result,
         ]);
     }
 
@@ -183,15 +181,15 @@ class GetSpendingInsightsTool extends Tool
 
         $breakdown = $rows->map(fn ($r) => [
             'method' => $r->method,
-            'total'  => round((float) $r->total, 2),
-            'count'  => (int) $r->cnt,
+            'total' => round((float) $r->total, 2),
+            'count' => (int) $r->cnt,
         ])->values()->all();
 
         return json_encode([
-            'success'    => true,
+            'success' => true,
             'query_type' => 'payment_breakdown',
-            'period'     => $period,
-            'breakdown'  => $breakdown,
+            'period' => $period,
+            'breakdown' => $breakdown,
         ]);
     }
 
@@ -209,7 +207,7 @@ class GetSpendingInsightsTool extends Tool
         foreach ($rows as $row) {
             $tags = array_filter(array_map('trim', explode(',', $row->tags)));
             foreach ($tags as $tag) {
-                if (!isset($tagMap[$tag])) {
+                if (! isset($tagMap[$tag])) {
                     $tagMap[$tag] = ['tag' => $tag, 'total' => 0.0, 'count' => 0];
                 }
                 $tagMap[$tag]['total'] += (float) $row->amount;
@@ -219,17 +217,17 @@ class GetSpendingInsightsTool extends Tool
 
         usort($tagMap, fn ($a, $b) => $b['total'] <=> $a['total']);
         $tagMap = array_values(array_map(fn ($t) => [
-            'tag'   => $t['tag'],
+            'tag' => $t['tag'],
             'total' => round($t['total'], 2),
             'count' => $t['count'],
         ], $tagMap));
 
         return json_encode([
-            'success'    => true,
+            'success' => true,
             'query_type' => 'tag_summary',
-            'period'     => $period,
+            'period' => $period,
             'total_tags' => count($tagMap),
-            'tags'       => $tagMap,
+            'tags' => $tagMap,
         ]);
     }
 
@@ -248,11 +246,11 @@ class GetSpendingInsightsTool extends Tool
 
         foreach ($rows as $row) {
             $dow = (int) $row->transaction_date->dayOfWeek; // 0=Sun
-            if (!isset($dayMap[$dow])) {
-                $dayMap[$dow]   = 0.0;
+            if (! isset($dayMap[$dow])) {
+                $dayMap[$dow] = 0.0;
                 $dayCounts[$dow] = 0;
             }
-            $dayMap[$dow]   += (float) $row->amount;
+            $dayMap[$dow] += (float) $row->amount;
             $dayCounts[$dow]++;
         }
 
@@ -261,9 +259,9 @@ class GetSpendingInsightsTool extends Tool
             $total = $dayMap[$idx] ?? 0.0;
             $count = $dayCounts[$idx] ?? 0;
             $breakdown[] = [
-                'day'     => $name,
-                'total'   => round($total, 2),
-                'count'   => $count,
+                'day' => $name,
+                'total' => round($total, 2),
+                'count' => $count,
                 'average' => $count > 0 ? round($total / $count, 2) : 0,
             ];
         }
@@ -272,11 +270,11 @@ class GetSpendingInsightsTool extends Tool
         $busiest = $breakdown[0]['day'] ?? 'N/A';
 
         return json_encode([
-            'success'      => true,
-            'query_type'   => 'day_breakdown',
-            'period'       => $period,
-            'busiest_day'  => $busiest,
-            'breakdown'    => $breakdown,
+            'success' => true,
+            'query_type' => 'day_breakdown',
+            'period' => $period,
+            'busiest_day' => $busiest,
+            'breakdown' => $breakdown,
         ]);
     }
 }

--- a/app/AI/Tools/ManageResourceTool.php
+++ b/app/AI/Tools/ManageResourceTool.php
@@ -16,10 +16,10 @@ class ManageResourceTool extends Tool
         $this
             ->as('manage_resource')
             ->for(
-                'Create, update, or delete a budget, category, or transaction. ' .
-                'action=create: creates the resource. ' .
-                'action=update: patches a transaction (resource_id required). ' .
-                'action=delete: removes a transaction or deactivates a budget (resource_id + confirmed required). ' .
+                'Create, update, or delete a budget, category, or transaction. '.
+                'action=create: creates the resource. '.
+                'action=update: patches a transaction (resource_id required). '.
+                'action=delete: removes a transaction or deactivates a budget (resource_id + confirmed required). '.
                 'For deletes, always call with confirmed=no first so the user can review, then confirmed=yes only after they say yes.'
             )
             ->withEnumParameter('action', 'What to do: create, update, or delete', ['create', 'update', 'delete'])
@@ -42,38 +42,38 @@ class ManageResourceTool extends Tool
     }
 
     public function execute(
-        string  $action,
-        string  $resource,
-        ?float  $resource_id        = null,
-        ?string $confirmed          = null,
-        ?string $name               = null,
-        ?float  $amount             = null,
-        ?string $category_name      = null,
+        string $action,
+        string $resource,
+        ?float $resource_id = null,
+        ?string $confirmed = null,
+        ?string $name = null,
+        ?float $amount = null,
+        ?string $category_name = null,
         ?string $parent_category_name = null,
-        ?string $description        = null,
-        ?string $period_type        = null,
-        ?string $start_date         = null,
-        ?string $end_date           = null,
-        ?string $transaction_type   = null,
-        ?string $date               = null,
-        ?string $notes              = null,
+        ?string $description = null,
+        ?string $period_type = null,
+        ?string $start_date = null,
+        ?string $end_date = null,
+        ?string $transaction_type = null,
+        ?string $date = null,
+        ?string $notes = null,
     ): string {
         try {
             return match (true) {
-                $action === 'create' && $resource === 'budget'      => $this->createBudget($name, $amount, $category_name, $period_type, $start_date, $end_date, $notes),
-                $action === 'create' && $resource === 'category'    => $this->createCategory($name, $parent_category_name, $description),
+                $action === 'create' && $resource === 'budget' => $this->createBudget($name, $amount, $category_name, $period_type, $start_date, $end_date, $notes),
+                $action === 'create' && $resource === 'category' => $this->createCategory($name, $parent_category_name, $description),
                 $action === 'update' && $resource === 'transaction' => $this->updateTransaction((int) $resource_id, $amount, $description, $date, $category_name, $transaction_type),
                 $action === 'delete' && $resource === 'transaction' => $this->deleteTransaction((int) $resource_id, $confirmed),
-                $action === 'delete' && $resource === 'budget'      => $this->deleteBudget((int) $resource_id, $confirmed),
+                $action === 'delete' && $resource === 'budget' => $this->deleteBudget((int) $resource_id, $confirmed),
                 default => json_encode([
                     'success' => false,
-                    'error'   => "Unsupported combination: action={$action}, resource={$resource}.",
+                    'error' => "Unsupported combination: action={$action}, resource={$resource}.",
                 ]),
             };
         } catch (\Throwable $e) {
             return json_encode([
                 'success' => false,
-                'error'   => 'manage_resource failed: ' . $e->getMessage(),
+                'error' => 'manage_resource failed: '.$e->getMessage(),
             ]);
         }
     }
@@ -84,25 +84,25 @@ class ManageResourceTool extends Tool
 
     private function createBudget(
         ?string $name,
-        ?float  $amount,
+        ?float $amount,
         ?string $categoryName,
         ?string $periodType,
         ?string $startDate,
         ?string $endDate,
         ?string $notes,
     ): string {
-        if (!$amount || $amount <= 0) {
+        if (! $amount || $amount <= 0) {
             return json_encode(['success' => false, 'error' => 'amount is required and must be > 0 to create a budget.']);
         }
         if (empty($categoryName)) {
             return json_encode(['success' => false, 'error' => 'category_name is required to create a budget.']);
         }
 
-        $category = Category::where('name', 'like', '%' . $categoryName . '%')
+        $category = Category::where('name', 'like', '%'.$categoryName.'%')
             ->where('is_active', true)
             ->first();
 
-        if (!$category) {
+        if (! $category) {
             return json_encode(['success' => false, 'error' => "Category \"{$categoryName}\" not found. Use list_categories to see available options."]);
         }
 
@@ -115,7 +115,7 @@ class ManageResourceTool extends Tool
             ],
             'custom' => [
                 $startDate ?? Carbon::today()->toDateString(),
-                $endDate   ?? Carbon::today()->addMonthNoOverflow()->toDateString(),
+                $endDate ?? Carbon::today()->addMonthNoOverflow()->toDateString(),
             ],
             default => [ // monthly
                 Carbon::now()->startOfMonth()->toDateString(),
@@ -125,43 +125,43 @@ class ManageResourceTool extends Tool
 
         $budget = Budget::create([
             'category_id' => $category->id,
-            'name'        => $name ?: $category->name . ' Budget',
-            'amount'      => $amount,
+            'name' => $name ?: $category->name.' Budget',
+            'amount' => $amount,
             'period_type' => $period,
-            'start_date'  => $start,
-            'end_date'    => $end,
-            'is_active'   => true,
-            'notes'       => $notes,
+            'start_date' => $start,
+            'end_date' => $end,
+            'is_active' => true,
+            'notes' => $notes,
         ]);
 
         return json_encode([
-            'success'     => true,
-            'id'          => $budget->id,
-            'message'     => "Budget \"{$budget->name}\" created: ₹{$amount} for {$category->name} ({$period}, {$start} → {$end}).",
-            'category'    => $category->name,
+            'success' => true,
+            'id' => $budget->id,
+            'message' => "Budget \"{$budget->name}\" created: ₹{$amount} for {$category->name} ({$period}, {$start} → {$end}).",
+            'category' => $category->name,
             'period_type' => $period,
-            'start_date'  => $start,
-            'end_date'    => $end,
+            'start_date' => $start,
+            'end_date' => $end,
         ]);
     }
 
     private function deleteBudget(int $id, ?string $confirmed): string
     {
         $budget = Budget::with('category')->find($id);
-        if (!$budget) {
+        if (! $budget) {
             return json_encode(['success' => false, 'error' => "Budget ID {$id} not found."]);
         }
 
         if ($confirmed !== 'yes') {
             return json_encode([
-                'success'  => false,
+                'success' => false,
                 'pending_confirmation' => true,
-                'message'  => "Please confirm: deactivate budget \"{$budget->name}\" (₹{$budget->amount} for {$budget->category?->name})? Reply yes to confirm.",
-                'budget'   => [
-                    'id'       => $budget->id,
-                    'name'     => $budget->name,
+                'message' => "Please confirm: deactivate budget \"{$budget->name}\" (₹{$budget->amount} for {$budget->category?->name})? Reply yes to confirm.",
+                'budget' => [
+                    'id' => $budget->id,
+                    'name' => $budget->name,
                     'category' => $budget->category?->name,
-                    'amount'   => (float) $budget->amount,
+                    'amount' => (float) $budget->amount,
                 ],
             ]);
         }
@@ -189,34 +189,34 @@ class ManageResourceTool extends Tool
         if ($existing) {
             return json_encode([
                 'success' => false,
-                'error'   => "Category \"{$name}\" already exists (ID: {$existing->id}).",
+                'error' => "Category \"{$name}\" already exists (ID: {$existing->id}).",
             ]);
         }
 
         $parentId = null;
-        if (!empty($parentName)) {
-            $parent = Category::where('name', 'like', '%' . $parentName . '%')
+        if (! empty($parentName)) {
+            $parent = Category::where('name', 'like', '%'.$parentName.'%')
                 ->whereNull('parent_id')
                 ->first();
-            if (!$parent) {
+            if (! $parent) {
                 return json_encode(['success' => false, 'error' => "Parent category \"{$parentName}\" not found."]);
             }
             $parentId = $parent->id;
         }
 
         $category = Category::create([
-            'name'        => $name,
-            'parent_id'   => $parentId,
+            'name' => $name,
+            'parent_id' => $parentId,
             'description' => $description,
-            'is_active'   => true,
+            'is_active' => true,
         ]);
 
         return json_encode([
-            'success'  => true,
-            'id'       => $category->id,
-            'name'     => $category->name,
-            'parent'   => $parentId ? Category::find($parentId)?->name : null,
-            'message'  => "Category \"{$name}\" created successfully.",
+            'success' => true,
+            'id' => $category->id,
+            'name' => $category->name,
+            'parent' => $parentId ? Category::find($parentId)?->name : null,
+            'message' => "Category \"{$name}\" created successfully.",
         ]);
     }
 
@@ -225,19 +225,19 @@ class ManageResourceTool extends Tool
     // -------------------------------------------------------------------------
 
     private function updateTransaction(
-        int     $id,
-        ?float  $amount,
+        int $id,
+        ?float $amount,
         ?string $description,
         ?string $date,
         ?string $categoryName,
         ?string $transactionType,
     ): string {
-        if (!$id) {
+        if (! $id) {
             return json_encode(['success' => false, 'error' => 'resource_id is required to update a transaction.']);
         }
 
         $transaction = Transaction::find($id);
-        if (!$transaction) {
+        if (! $transaction) {
             return json_encode(['success' => false, 'error' => "Transaction ID {$id} not found."]);
         }
 
@@ -246,21 +246,21 @@ class ManageResourceTool extends Tool
         if ($amount !== null && $amount > 0) {
             $updates['amount'] = $amount;
         }
-        if (!empty($description)) {
+        if (! empty($description)) {
             $updates['description'] = $description;
         }
-        if (!empty($date)) {
+        if (! empty($date)) {
             try {
                 $updates['transaction_date'] = Carbon::parse($date)->toDateString();
             } catch (\Throwable) {
                 return json_encode(['success' => false, 'error' => "Invalid date format: {$date}. Use YYYY-MM-DD."]);
             }
         }
-        if (!empty($transactionType)) {
+        if (! empty($transactionType)) {
             $updates['transaction_type'] = $transactionType;
         }
-        if (!empty($categoryName)) {
-            $category = Category::where('name', 'like', '%' . $categoryName . '%')
+        if (! empty($categoryName)) {
+            $category = Category::where('name', 'like', '%'.$categoryName.'%')
                 ->whereNotNull('parent_id')
                 ->first();
             if ($category) {
@@ -276,44 +276,44 @@ class ManageResourceTool extends Tool
         $transaction->refresh();
 
         return json_encode([
-            'success'     => true,
-            'message'     => "Transaction ID {$id} updated successfully.",
+            'success' => true,
+            'message' => "Transaction ID {$id} updated successfully.",
             'transaction' => [
-                'id'          => $transaction->id,
-                'date'        => $transaction->transaction_date->format('Y-m-d'),
+                'id' => $transaction->id,
+                'date' => $transaction->transaction_date->format('Y-m-d'),
                 'description' => $transaction->description,
-                'amount'      => (float) $transaction->amount,
-                'type'        => $transaction->transaction_type,
-                'category'    => $transaction->category?->name,
-                'account'     => $transaction->account?->name,
+                'amount' => (float) $transaction->amount,
+                'type' => $transaction->transaction_type,
+                'category' => $transaction->category?->name,
+                'account' => $transaction->account?->name,
             ],
         ]);
     }
 
     private function deleteTransaction(int $id, ?string $confirmed): string
     {
-        if (!$id) {
+        if (! $id) {
             return json_encode(['success' => false, 'error' => 'resource_id is required to delete a transaction.']);
         }
 
         $transaction = Transaction::with(['category', 'account'])->find($id);
-        if (!$transaction) {
+        if (! $transaction) {
             return json_encode(['success' => false, 'error' => "Transaction ID {$id} not found."]);
         }
 
         if ($confirmed !== 'yes') {
             return json_encode([
-                'success'              => false,
+                'success' => false,
                 'pending_confirmation' => true,
-                'message'              => "Please confirm deletion of: ₹{$transaction->amount} — \"{$transaction->description}\" on {$transaction->transaction_date->format('Y-m-d')}. Reply yes to confirm.",
-                'transaction'          => [
-                    'id'          => $transaction->id,
-                    'date'        => $transaction->transaction_date->format('Y-m-d'),
+                'message' => "Please confirm deletion of: ₹{$transaction->amount} — \"{$transaction->description}\" on {$transaction->transaction_date->format('Y-m-d')}. Reply yes to confirm.",
+                'transaction' => [
+                    'id' => $transaction->id,
+                    'date' => $transaction->transaction_date->format('Y-m-d'),
                     'description' => $transaction->description,
-                    'amount'      => (float) $transaction->amount,
-                    'type'        => $transaction->transaction_type,
-                    'category'    => $transaction->category?->name,
-                    'account'     => $transaction->account?->name,
+                    'amount' => (float) $transaction->amount,
+                    'type' => $transaction->transaction_type,
+                    'category' => $transaction->category?->name,
+                    'account' => $transaction->account?->name,
                 ],
             ]);
         }

--- a/app/AI/Tools/QueryExpensesTool.php
+++ b/app/AI/Tools/QueryExpensesTool.php
@@ -53,8 +53,7 @@ class QueryExpensesTool extends Tool
                 ->limit(3)
                 ->get();
 
-            $categoryBreakdown = $topCategories->map(fn ($t) =>
-                ($t->category?->name ?? 'Uncategorized').': ₹'.number_format($t->total, 2).' ('.$t->count.' txn)'
+            $categoryBreakdown = $topCategories->map(fn ($t) => ($t->category?->name ?? 'Uncategorized').': ₹'.number_format($t->total, 2).' ('.$t->count.' txn)'
             )->join(', ');
 
             $incomeTotal = 0;

--- a/app/AI/Tools/SearchTransactionsTool.php
+++ b/app/AI/Tools/SearchTransactionsTool.php
@@ -15,10 +15,10 @@ class SearchTransactionsTool extends Tool
         $this
             ->as('search_transactions')
             ->for(
-                'Search and filter transactions with full control over category, account, date range, description, payment method, and tags. ' .
-                'Use after list_categories to get real category IDs. ' .
-                'All parameters are optional except type. ' .
-                'Use list_limit (1–50) to control how many rows are returned. ' .
+                'Search and filter transactions with full control over category, account, date range, description, payment method, and tags. '.
+                'Use after list_categories to get real category IDs. '.
+                'All parameters are optional except type. '.
+                'Use list_limit (1–50) to control how many rows are returned. '.
                 'Returns matching transactions plus aggregate totals and the matched category names.'
             )
             ->withEnumParameter(
@@ -77,16 +77,16 @@ class SearchTransactionsTool extends Tool
     }
 
     public function execute(
-        string  $type,
-        ?string $category_ids      = null,
-        ?string $from_date         = null,
-        ?string $to_date           = null,
+        string $type,
+        ?string $category_ids = null,
+        ?string $from_date = null,
+        ?string $to_date = null,
         ?string $description_search = null,
-        ?string $account_name      = null,
-        ?string $payment_method    = null,
-        ?string $tags              = null,
-        ?float  $list_limit        = null,
-        ?string $sort_by           = null,
+        ?string $account_name = null,
+        ?string $payment_method = null,
+        ?string $tags = null,
+        ?float $list_limit = null,
+        ?string $sort_by = null,
     ): string {
         try {
             $query = Transaction::with(['category.parent', 'account']);
@@ -98,9 +98,9 @@ class SearchTransactionsTool extends Tool
 
             // Category filter via comma-separated IDs
             $matchedCategories = [];
-            if (!empty($category_ids)) {
+            if (! empty($category_ids)) {
                 $ids = array_filter(array_map('intval', explode(',', $category_ids)));
-                if (!empty($ids)) {
+                if (! empty($ids)) {
                     $query->whereIn('category_id', $ids);
                     $matchedCategories = Category::whereIn('id', $ids)
                         ->pluck('name')
@@ -110,14 +110,14 @@ class SearchTransactionsTool extends Tool
             }
 
             // Date range filters
-            if (!empty($from_date)) {
+            if (! empty($from_date)) {
                 try {
                     $query->whereDate('transaction_date', '>=', Carbon::parse($from_date)->toDateString());
                 } catch (\Throwable) {
                     // ignore unparseable date
                 }
             }
-            if (!empty($to_date)) {
+            if (! empty($to_date)) {
                 try {
                     $query->whereDate('transaction_date', '<=', Carbon::parse($to_date)->toDateString());
                 } catch (\Throwable) {
@@ -126,88 +126,88 @@ class SearchTransactionsTool extends Tool
             }
 
             // Description keyword search
-            if (!empty($description_search)) {
-                $query->where('description', 'like', '%' . $description_search . '%');
+            if (! empty($description_search)) {
+                $query->where('description', 'like', '%'.$description_search.'%');
             }
 
             // Account name filter
-            if (!empty($account_name)) {
-                $accountIds = Account::where('name', 'like', '%' . $account_name . '%')
+            if (! empty($account_name)) {
+                $accountIds = Account::where('name', 'like', '%'.$account_name.'%')
                     ->pluck('id');
                 $query->whereIn('account_id', $accountIds);
             }
 
             // Payment method filter
-            if (!empty($payment_method)) {
+            if (! empty($payment_method)) {
                 $query->where('payment_method', $payment_method);
             }
 
             // Tags keyword search
-            if (!empty($tags)) {
-                $query->where('tags', 'like', '%' . $tags . '%');
+            if (! empty($tags)) {
+                $query->where('tags', 'like', '%'.$tags.'%');
             }
 
             // Aggregates (on filtered base query before limit/sort)
-            $total   = (clone $query)->sum('amount');
-            $count   = (clone $query)->count();
-            $income  = $type === 'both' ? (clone $query)->where('transaction_type', 'income')->sum('amount') : null;
+            $total = (clone $query)->sum('amount');
+            $count = (clone $query)->count();
+            $income = $type === 'both' ? (clone $query)->where('transaction_type', 'income')->sum('amount') : null;
             $expense = $type === 'both' ? (clone $query)->where('transaction_type', 'expense')->sum('amount') : null;
 
             // Sort
             $sort = $sort_by ?? 'newest';
             match ($sort) {
-                'oldest'      => $query->orderBy('transaction_date')->orderBy('id'),
+                'oldest' => $query->orderBy('transaction_date')->orderBy('id'),
                 'amount_desc' => $query->orderByDesc('amount'),
-                'amount_asc'  => $query->orderBy('amount'),
-                default       => $query->orderByDesc('transaction_date')->orderByDesc('id'),
+                'amount_asc' => $query->orderBy('amount'),
+                default => $query->orderByDesc('transaction_date')->orderByDesc('id'),
             };
 
             // Limit rows returned
             $limit = $list_limit !== null ? max(1, min(50, (int) round($list_limit))) : 10;
-            $rows  = $query->limit($limit)->get();
+            $rows = $query->limit($limit)->get();
 
             $transactions = $rows->map(fn (Transaction $t) => [
-                'id'             => $t->id,
-                'date'           => $t->transaction_date->format('Y-m-d'),
-                'description'    => $t->description,
-                'amount'         => (float) $t->amount,
-                'type'           => $t->transaction_type,
-                'category'       => $t->category?->name,
-                'parent_category'=> $t->category?->parent?->name,
-                'account'        => $t->account?->name,
+                'id' => $t->id,
+                'date' => $t->transaction_date->format('Y-m-d'),
+                'description' => $t->description,
+                'amount' => (float) $t->amount,
+                'type' => $t->transaction_type,
+                'category' => $t->category?->name,
+                'parent_category' => $t->category?->parent?->name,
+                'account' => $t->account?->name,
                 'payment_method' => $t->payment_method,
-                'tags'           => $t->tags,
+                'tags' => $t->tags,
             ])->values()->all();
 
             return json_encode([
-                'success'           => true,
-                'filters_applied'   => array_filter([
-                    'type'               => $type,
-                    'category_ids'       => $category_ids,
+                'success' => true,
+                'filters_applied' => array_filter([
+                    'type' => $type,
+                    'category_ids' => $category_ids,
                     'matched_categories' => $matchedCategories ?: null,
-                    'from_date'          => $from_date,
-                    'to_date'            => $to_date,
+                    'from_date' => $from_date,
+                    'to_date' => $to_date,
                     'description_search' => $description_search,
-                    'account_name'       => $account_name,
-                    'payment_method'     => $payment_method,
-                    'tags'               => $tags,
-                    'sort_by'            => $sort,
+                    'account_name' => $account_name,
+                    'payment_method' => $payment_method,
+                    'tags' => $tags,
+                    'sort_by' => $sort,
                 ]),
-                'total'             => number_format((float) $total, 2),
-                'count'             => $count,
-                'income_total'      => $income !== null ? number_format((float) $income, 2) : null,
-                'expense_total'     => $expense !== null ? number_format((float) $expense, 2) : null,
-                'net'               => ($income !== null && $expense !== null)
+                'total' => number_format((float) $total, 2),
+                'count' => $count,
+                'income_total' => $income !== null ? number_format((float) $income, 2) : null,
+                'expense_total' => $expense !== null ? number_format((float) $expense, 2) : null,
+                'net' => ($income !== null && $expense !== null)
                                         ? number_format((float) $income - (float) $expense, 2)
                                         : null,
-                'showing'          => count($transactions) . ' of ' . $count,
-                'transactions'      => $transactions,
+                'showing' => count($transactions).' of '.$count,
+                'transactions' => $transactions,
             ]);
 
         } catch (\Throwable $e) {
             return json_encode([
                 'success' => false,
-                'error'   => 'Search failed: ' . $e->getMessage(),
+                'error' => 'Search failed: '.$e->getMessage(),
             ]);
         }
     }

--- a/app/Console/Commands/RecalculateAccountBalances.php
+++ b/app/Console/Commands/RecalculateAccountBalances.php
@@ -2,8 +2,8 @@
 
 namespace App\Console\Commands;
 
-use Illuminate\Console\Command;
 use App\Models\Account;
+use Illuminate\Console\Command;
 
 class RecalculateAccountBalances extends Command
 {
@@ -32,8 +32,9 @@ class RecalculateAccountBalances extends Command
             // Recalculate specific account
             $account = Account::find($accountId);
 
-            if (!$account) {
+            if (! $account) {
                 $this->error("Account with ID {$accountId} not found.");
+
                 return 1;
             }
 
@@ -41,10 +42,10 @@ class RecalculateAccountBalances extends Command
             $newBalance = $account->recalculateBalance();
 
             $this->info("Account: {$account->name} (ID: {$account->id})");
-            $this->info("Old Balance: ₹" . number_format($oldBalance, 2));
-            $this->info("New Balance: ₹" . number_format($newBalance, 2));
-            $this->info("Difference: ₹" . number_format($newBalance - $oldBalance, 2));
-            $this->info("✅ Balance recalculated successfully!");
+            $this->info('Old Balance: ₹'.number_format($oldBalance, 2));
+            $this->info('New Balance: ₹'.number_format($newBalance, 2));
+            $this->info('Difference: ₹'.number_format($newBalance - $oldBalance, 2));
+            $this->info('✅ Balance recalculated successfully!');
         } else {
             // Recalculate all accounts
             $accounts = Account::all();
@@ -55,7 +56,7 @@ class RecalculateAccountBalances extends Command
             });
 
             $this->newLine(2);
-            $this->info("✅ All account balances recalculated successfully!");
+            $this->info('✅ All account balances recalculated successfully!');
         }
 
         return 0;

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -40,7 +40,7 @@ class AccountController extends Controller
         $validated = $request->validate([
             'code' => 'required|string|max:20|unique:accounts,code',
             'name' => 'required|string|max:100',
-            'type' => 'required|string|max:20|in:' . implode(',', array_keys(Account::getTypes())),
+            'type' => 'required|string|max:20|in:'.implode(',', array_keys(Account::getTypes())),
             'bank_name' => 'nullable|string|max:100',
             'account_number' => 'nullable|string|max:50',
             'ifsc_code' => 'nullable|string|max:20',
@@ -89,9 +89,9 @@ class AccountController extends Controller
     public function update(Request $request, Account $account)
     {
         $validated = $request->validate([
-            'code' => 'required|string|max:20|unique:accounts,code,' . $account->id,
+            'code' => 'required|string|max:20|unique:accounts,code,'.$account->id,
             'name' => 'required|string|max:100',
-            'type' => 'required|string|max:20|in:' . implode(',', array_keys(Account::getTypes())),
+            'type' => 'required|string|max:20|in:'.implode(',', array_keys(Account::getTypes())),
             'bank_name' => 'nullable|string|max:100',
             'account_number' => 'nullable|string|max:50',
             'ifsc_code' => 'nullable|string|max:20',
@@ -128,7 +128,7 @@ class AccountController extends Controller
      */
     public function toggleStatus(Account $account)
     {
-        $account->update(['is_active' => !$account->is_active]);
+        $account->update(['is_active' => ! $account->is_active]);
 
         $status = $account->is_active ? 'activated' : 'deactivated';
 
@@ -142,7 +142,7 @@ class AccountController extends Controller
     public function getAccounts()
     {
         return response()->json([
-            'accounts' => Account::active()->orderBy('name')->get()
+            'accounts' => Account::active()->orderBy('name')->get(),
         ]);
     }
 }

--- a/app/Http/Controllers/Api/StatsController.php
+++ b/app/Http/Controllers/Api/StatsController.php
@@ -3,9 +3,10 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use App\Models\Transaction;
 use App\Models\Account;
+use App\Models\Transaction;
 use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class StatsController extends Controller
@@ -13,7 +14,7 @@ class StatsController extends Controller
     /**
      * Get today's income and expense statistics
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function today()
     {
@@ -41,7 +42,7 @@ class StatsController extends Controller
     /**
      * Get current week's income and expense statistics
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function weekly()
     {
@@ -93,7 +94,7 @@ class StatsController extends Controller
     /**
      * Get current month's income and expense statistics
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function monthly()
     {
@@ -125,7 +126,7 @@ class StatsController extends Controller
     /**
      * Get total current balance across all active accounts
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function balance()
     {
@@ -154,7 +155,7 @@ class StatsController extends Controller
     /**
      * Get comprehensive dashboard statistics
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function dashboard()
     {
@@ -231,8 +232,7 @@ class StatsController extends Controller
     /**
      * Get custom date range statistics
      *
-     * @param Request $request
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function dateRange(Request $request)
     {

--- a/app/Http/Controllers/BudgetController.php
+++ b/app/Http/Controllers/BudgetController.php
@@ -5,9 +5,8 @@ namespace App\Http\Controllers;
 use App\Models\Budget;
 use App\Models\Category;
 use Illuminate\Http\Request;
-use Inertia\Inertia;
 use Illuminate\Support\Facades\Redirect;
-use Carbon\Carbon;
+use Inertia\Inertia;
 
 class BudgetController extends Controller
 {
@@ -40,8 +39,8 @@ class BudgetController extends Controller
         }
 
         $budgets = $query->orderBy('start_date', 'desc')
-                        ->paginate($perPage)
-                        ->appends($request->query());
+            ->paginate($perPage)
+            ->appends($request->query());
 
         // Add computed attributes to each budget
         $budgets->getCollection()->transform(function ($budget) {
@@ -49,6 +48,7 @@ class BudgetController extends Controller
             $budget->remaining_amount = $budget->remaining_amount;
             $budget->percentage_used = $budget->percentage_used;
             $budget->status = $budget->status;
+
             return $budget;
         });
 
@@ -95,13 +95,13 @@ class BudgetController extends Controller
         // Check for overlapping budgets for the same category
         $overlapping = Budget::where('category_id', $validated['category_id'])
             ->where('is_active', true)
-            ->where(function($query) use ($validated) {
+            ->where(function ($query) use ($validated) {
                 $query->whereBetween('start_date', [$validated['start_date'], $validated['end_date']])
-                      ->orWhereBetween('end_date', [$validated['start_date'], $validated['end_date']])
-                      ->orWhere(function($q) use ($validated) {
-                          $q->where('start_date', '<=', $validated['start_date'])
+                    ->orWhereBetween('end_date', [$validated['start_date'], $validated['end_date']])
+                    ->orWhere(function ($q) use ($validated) {
+                        $q->where('start_date', '<=', $validated['start_date'])
                             ->where('end_date', '>=', $validated['end_date']);
-                      });
+                    });
             })
             ->exists();
 
@@ -176,13 +176,13 @@ class BudgetController extends Controller
         $overlapping = Budget::where('category_id', $validated['category_id'])
             ->where('id', '!=', $budget->id)
             ->where('is_active', true)
-            ->where(function($query) use ($validated) {
+            ->where(function ($query) use ($validated) {
                 $query->whereBetween('start_date', [$validated['start_date'], $validated['end_date']])
-                      ->orWhereBetween('end_date', [$validated['start_date'], $validated['end_date']])
-                      ->orWhere(function($q) use ($validated) {
-                          $q->where('start_date', '<=', $validated['start_date'])
+                    ->orWhereBetween('end_date', [$validated['start_date'], $validated['end_date']])
+                    ->orWhere(function ($q) use ($validated) {
+                        $q->where('start_date', '<=', $validated['start_date'])
                             ->where('end_date', '>=', $validated['end_date']);
-                      });
+                    });
             })
             ->exists();
 
@@ -214,7 +214,7 @@ class BudgetController extends Controller
      */
     public function toggleStatus(Budget $budget)
     {
-        $budget->update(['is_active' => !$budget->is_active]);
+        $budget->update(['is_active' => ! $budget->is_active]);
 
         $status = $budget->is_active ? 'activated' : 'deactivated';
 

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Category;
+use App\Models\Transaction;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
 use Inertia\Inertia;
@@ -16,9 +17,9 @@ class CategoryController extends Controller
     {
         $perPage = $request->get('per_page', 5); // Changed to 5 parent categories per page
         $page = $request->get('page', 1);
-        
+
         // Validate per_page parameter
-        if (!in_array($perPage, [5, 10, 15, 20])) {
+        if (! in_array($perPage, [5, 10, 15, 20])) {
             $perPage = 5;
         }
 
@@ -28,45 +29,46 @@ class CategoryController extends Controller
             ->get();
 
         // Load transaction counts separately for efficiency
-        $categoriesWithTransactionTotals = $allCategories->map(function($category) {
+        $categoriesWithTransactionTotals = $allCategories->map(function ($category) {
             // Calculate totals
             if ($category->isParent()) {
                 // For parent categories, get sum of all children + parent
                 $childrenIds = $category->children->pluck('id')->toArray();
                 $allIds = array_merge($childrenIds, [$category->id]);
-                
+
                 // Set the main total properties (sum of all subcategories)
-                $totalAmount = \App\Models\Transaction::whereIn('category_id', $allIds)->sum('amount');
-                $transactionCount = \App\Models\Transaction::whereIn('category_id', $allIds)->count();
-                
+                $totalAmount = Transaction::whereIn('category_id', $allIds)->sum('amount');
+                $transactionCount = Transaction::whereIn('category_id', $allIds)->count();
+
                 $category->total_amount = $totalAmount;
                 $category->transactions_count = $transactionCount;
-                
+
                 // Also set the _with_children properties for API compatibility
                 $category->total_amount_with_children = $totalAmount;
                 $category->transaction_count_with_children = $transactionCount;
             } else {
                 // For children, just get their individual totals
-                $totalAmount = \App\Models\Transaction::where('category_id', $category->id)->sum('amount');
-                $transactionCount = \App\Models\Transaction::where('category_id', $category->id)->count();
-                
+                $totalAmount = Transaction::where('category_id', $category->id)->sum('amount');
+                $transactionCount = Transaction::where('category_id', $category->id)->count();
+
                 $category->total_amount = $totalAmount;
                 $category->transactions_count = $transactionCount;
             }
-            
+
             return $category;
         });
 
         // Group into parent categories with their children
-        $parentCategories = $categoriesWithTransactionTotals->filter(function($category) {
+        $parentCategories = $categoriesWithTransactionTotals->filter(function ($category) {
             return $category->parent_id === null;
         });
 
         // Add children to each parent
-        $groupedCategories = $parentCategories->map(function($parent) use ($categoriesWithTransactionTotals) {
-            $parent->children = $categoriesWithTransactionTotals->filter(function($category) use ($parent) {
+        $groupedCategories = $parentCategories->map(function ($parent) use ($categoriesWithTransactionTotals) {
+            $parent->children = $categoriesWithTransactionTotals->filter(function ($category) use ($parent) {
                 return $category->parent_id === $parent->id;
             })->values();
+
             return $parent;
         });
 
@@ -151,7 +153,7 @@ class CategoryController extends Controller
     {
         // Load relationships
         $category->load(['parent', 'children']);
-        
+
         // Get transactions for this category
         $transactions = $category->transactions()
             ->with(['account'])
@@ -159,21 +161,21 @@ class CategoryController extends Controller
             ->orderBy('created_at', 'desc')
             ->limit(10)
             ->get();
-        
+
         // Calculate statistics
         if ($category->parent_id === null) {
             // For parent categories, include children's transactions
             $childrenIds = $category->children->pluck('id')->toArray();
             $allIds = array_merge($childrenIds, [$category->id]);
-            
-            $totalAmount = \App\Models\Transaction::whereIn('category_id', $allIds)->sum('amount');
-            $transactionCount = \App\Models\Transaction::whereIn('category_id', $allIds)->count();
-            
+
+            $totalAmount = Transaction::whereIn('category_id', $allIds)->sum('amount');
+            $transactionCount = Transaction::whereIn('category_id', $allIds)->count();
+
             // Get breakdown by child
-            $childrenStats = $category->children->map(function($child) {
-                $childAmount = \App\Models\Transaction::where('category_id', $child->id)->sum('amount');
-                $childCount = \App\Models\Transaction::where('category_id', $child->id)->count();
-                
+            $childrenStats = $category->children->map(function ($child) {
+                $childAmount = Transaction::where('category_id', $child->id)->sum('amount');
+                $childCount = Transaction::where('category_id', $child->id)->count();
+
                 return [
                     'id' => $child->id,
                     'name' => $child->name,
@@ -185,11 +187,11 @@ class CategoryController extends Controller
             });
         } else {
             // For child categories
-            $totalAmount = \App\Models\Transaction::where('category_id', $category->id)->sum('amount');
-            $transactionCount = \App\Models\Transaction::where('category_id', $category->id)->count();
+            $totalAmount = Transaction::where('category_id', $category->id)->sum('amount');
+            $transactionCount = Transaction::where('category_id', $category->id)->count();
             $childrenStats = collect([]);
         }
-        
+
         return Inertia::render('Categories/Show', [
             'category' => $category,
             'transactions' => $transactions,
@@ -226,7 +228,7 @@ class CategoryController extends Controller
     {
         $validated = $request->validate([
             'name' => 'required|string|max:100',
-            'code' => 'required|string|max:50|unique:categories,code,' . $category->id,
+            'code' => 'required|string|max:50|unique:categories,code,'.$category->id,
             'parent_id' => 'nullable|exists:categories,id',
             'description' => 'nullable|string|max:1000',
             'icon' => 'nullable|string|max:50',
@@ -266,7 +268,7 @@ class CategoryController extends Controller
             }
 
             $category->delete();
-            
+
             return Redirect::route('categories.index')
                 ->with('success', 'Category deleted successfully.');
         } catch (\Exception $e) {
@@ -280,10 +282,10 @@ class CategoryController extends Controller
      */
     public function toggleStatus(Category $category)
     {
-        $category->update(['is_active' => !$category->is_active]);
-        
+        $category->update(['is_active' => ! $category->is_active]);
+
         $status = $category->is_active ? 'activated' : 'deactivated';
-        
+
         return Redirect::route('categories.index')
             ->with('success', "Category {$status} successfully.");
     }
@@ -294,7 +296,7 @@ class CategoryController extends Controller
     public function getCategories()
     {
         return response()->json([
-            'categories' => Category::active()->orderBy('name')->get()
+            'categories' => Category::active()->orderBy('name')->get(),
         ]);
     }
 
@@ -304,7 +306,7 @@ class CategoryController extends Controller
     public function getParentCategories()
     {
         return response()->json([
-            'categories' => Category::active()->parent()->orderBy('name')->get()
+            'categories' => Category::active()->parent()->orderBy('name')->get(),
         ]);
     }
 
@@ -314,7 +316,7 @@ class CategoryController extends Controller
     public function getChildCategories(Category $category)
     {
         return response()->json([
-            'categories' => $category->activeChildren()->orderBy('name')->get()
+            'categories' => $category->activeChildren()->orderBy('name')->get(),
         ]);
     }
 
@@ -332,10 +334,10 @@ class CategoryController extends Controller
             // Calculate totals for parent category
             $childrenIds = $category->children->pluck('id')->toArray();
             $allIds = array_merge($childrenIds, [$category->id]);
-            
-            $totalAmount = \App\Models\Transaction::whereIn('category_id', $allIds)->sum('amount');
-            $transactionCount = \App\Models\Transaction::whereIn('category_id', $allIds)->count();
-            
+
+            $totalAmount = Transaction::whereIn('category_id', $allIds)->sum('amount');
+            $transactionCount = Transaction::whereIn('category_id', $allIds)->count();
+
             return [
                 'id' => $category->id,
                 'name' => $category->name,
@@ -345,9 +347,9 @@ class CategoryController extends Controller
                 'total_amount' => $totalAmount,
                 'transaction_count' => $transactionCount,
                 'children' => $category->children->map(function ($child) {
-                    $childAmount = \App\Models\Transaction::where('category_id', $child->id)->sum('amount');
-                    $childCount = \App\Models\Transaction::where('category_id', $child->id)->count();
-                    
+                    $childAmount = Transaction::where('category_id', $child->id)->sum('amount');
+                    $childCount = Transaction::where('category_id', $child->id)->count();
+
                     return [
                         'id' => $child->id,
                         'name' => $child->name,
@@ -355,12 +357,12 @@ class CategoryController extends Controller
                         'total_amount' => $childAmount,
                         'transaction_count' => $childCount,
                     ];
-                })
+                }),
             ];
         });
 
         return response()->json([
-            'categories' => $categoriesWithTotals
+            'categories' => $categoriesWithTotals,
         ]);
     }
 }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -2,12 +2,12 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Transaction;
-use App\Models\Category;
 use App\Models\Account;
+use App\Models\Category;
+use App\Models\Transaction;
 use Carbon\Carbon;
-use Inertia\Inertia;
 use Illuminate\Support\Facades\DB;
+use Inertia\Inertia;
 
 class DashboardController extends Controller
 {
@@ -220,7 +220,7 @@ class DashboardController extends Controller
             ->map(function ($item) {
                 $categoryName = $item->category
                     ? ($item->category->parent
-                        ? $item->category->parent->name . ' > ' . $item->category->name
+                        ? $item->category->parent->name.' > '.$item->category->name
                         : $item->category->name)
                     : 'Uncategorized';
 

--- a/app/Models/Budget.php
+++ b/app/Models/Budget.php
@@ -4,7 +4,6 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 
 class Budget extends Model
 {
@@ -30,7 +29,9 @@ class Budget extends Model
 
     // Period types
     public const PERIOD_MONTHLY = 'monthly';
+
     public const PERIOD_YEARLY = 'yearly';
+
     public const PERIOD_CUSTOM = 'custom';
 
     public static function getPeriodTypes(): array
@@ -58,8 +59,9 @@ class Budget extends Model
     public function scopeCurrent($query)
     {
         $today = now();
+
         return $query->where('start_date', '<=', $today)
-                     ->where('end_date', '>=', $today);
+            ->where('end_date', '>=', $today);
     }
 
     // Get spent amount for this budget (includes child categories)
@@ -91,6 +93,7 @@ class Budget extends Model
         if ($this->amount <= 0) {
             return 0;
         }
+
         return min(100, round(($this->spent_amount / $this->amount) * 100, 1));
     }
 
@@ -118,6 +121,7 @@ class Budget extends Model
     public function isCurrent()
     {
         $today = now();
+
         return $today->between($this->start_date, $this->end_date);
     }
 }

--- a/app/Services/ChatService.php
+++ b/app/Services/ChatService.php
@@ -9,14 +9,14 @@ use App\AI\Tools\ListCategoriesTool;
 use App\AI\Tools\ManageResourceTool;
 use App\AI\Tools\QueryExpensesTool;
 use App\AI\Tools\SearchTransactionsTool;
-use App\Models\ChatSession;
 use App\Models\ChatMessage;
+use App\Models\ChatSession;
+use Carbon\Carbon;
 use Prism\Prism\Facades\Prism;
-use Prism\Prism\ValueObjects\Messages\UserMessage;
-use Prism\Prism\ValueObjects\Messages\AssistantMessage;
 use Prism\Prism\Streaming\Events\TextDeltaEvent;
 use Prism\Prism\Streaming\Events\ToolCallEvent;
-use Carbon\Carbon;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ChatService
@@ -42,8 +42,8 @@ class ChatService
         // Save user message immediately
         ChatMessage::create([
             'chat_session_id' => $session->id,
-            'role'            => 'user',
-            'content'         => $userMessage,
+            'role' => 'user',
+            'content' => $userMessage,
         ]);
 
         // Load conversation history (last 20 messages)
@@ -69,9 +69,9 @@ class ChatService
             config('ai.provider'),
             config('ai.model'),
             [
-                'user_message'   => $userMessage,
+                'user_message' => $userMessage,
                 'messages_count' => count($history),
-                'tools_count'    => 7,
+                'tools_count' => 7,
             ]
         );
 
@@ -87,13 +87,13 @@ class ChatService
                 ->withSystemPrompt($systemPrompt)
                 ->withMessages($history)
                 ->withTools([
-                    new CreateTransactionTool(),
-                    new QueryExpensesTool(),
-                    new ListCategoriesTool(),
-                    new SearchTransactionsTool(),
-                    new GetAccountBalancesTool(),
-                    new GetSpendingInsightsTool(),
-                    new ManageResourceTool(),
+                    new CreateTransactionTool,
+                    new QueryExpensesTool,
+                    new ListCategoriesTool,
+                    new SearchTransactionsTool,
+                    new GetAccountBalancesTool,
+                    new GetSpendingInsightsTool,
+                    new ManageResourceTool,
                 ])
                 ->withMaxSteps(config('ai.max_steps'))
                 ->withMaxTokens(config('ai.max_tokens', 4096))
@@ -118,10 +118,10 @@ class ChatService
             // Return error as SSE stream
             return new StreamedResponse(function () use ($e) {
                 echo "event: error\n";
-                echo "data: " . json_encode([
-                    'error'  => $e->getMessage(),
+                echo 'data: '.json_encode([
+                    'error' => $e->getMessage(),
                     'status' => 'error',
-                ]) . "\n\n";
+                ])."\n\n";
                 echo "event: stream-end\n";
                 echo "data: {}\n\n";
             }, 200, [
@@ -146,19 +146,19 @@ class ChatService
                 $finalText .= $event->delta;
             } elseif ($event instanceof ToolCallEvent) {
                 $toolCalls[] = [
-                    'name'      => $event->toolCall->name,
+                    'name' => $event->toolCall->name,
                     'arguments' => $event->toolCall->arguments,
                 ];
             }
         }
 
         // Save assistant message
-        if (!empty($finalText)) {
+        if (! empty($finalText)) {
             ChatMessage::create([
                 'chat_session_id' => $session->id,
-                'role'            => 'assistant',
-                'content'         => $finalText,
-                'tool_calls'      => !empty($toolCalls) ? $toolCalls : null,
+                'role' => 'assistant',
+                'content' => $finalText,
+                'tool_calls' => ! empty($toolCalls) ? $toolCalls : null,
             ]);
         }
 
@@ -167,7 +167,7 @@ class ChatService
             $session->session_id,
             $durationMs,
             [
-                'text_length'      => strlen($finalText),
+                'text_length' => strlen($finalText),
                 'tool_calls_count' => count($toolCalls),
             ]
         );

--- a/app/Services/LlmLoggingService.php
+++ b/app/Services/LlmLoggingService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\LlmLog;
 use Illuminate\Support\Facades\Log;
+use Psr\Log\LoggerInterface;
 use Throwable;
 
 class LlmLoggingService
@@ -16,7 +17,7 @@ class LlmLoggingService
         ];
     }
 
-    protected function llmLog(): \Psr\Log\LoggerInterface
+    protected function llmLog(): LoggerInterface
     {
         return Log::channel('llm');
     }
@@ -28,19 +29,19 @@ class LlmLoggingService
     {
         // Database log
         LlmLog::create([
-            'session_id'   => $sessionId,
-            'provider'     => $provider,
-            'model'        => $model,
+            'session_id' => $sessionId,
+            'provider' => $provider,
+            'model' => $model,
             'message_type' => 'request',
-            'content'      => $payload,
-            'status'       => 'success',
+            'content' => $payload,
+            'status' => 'success',
         ]);
 
         // File log
         $this->llmLog()->info("REQUEST [{$sessionId}]", [
             'provider' => $provider,
-            'model'    => $model,
-            'payload'  => $payload,
+            'model' => $model,
+            'payload' => $payload,
         ]);
     }
 
@@ -53,19 +54,19 @@ class LlmLoggingService
 
         // Database log
         LlmLog::create([
-            'session_id'   => $sessionId,
+            'session_id' => $sessionId,
             ...$meta,
             'message_type' => 'response',
-            'content'      => $payload,
-            'duration_ms'  => $durationMs,
-            'status'       => 'success',
+            'content' => $payload,
+            'duration_ms' => $durationMs,
+            'status' => 'success',
         ]);
 
         // File log
         $this->llmLog()->info("RESPONSE [{$sessionId}] ({$durationMs}ms)", [
             'provider' => $meta['provider'],
-            'model'    => $meta['model'],
-            'payload'  => $payload,
+            'model' => $meta['model'],
+            'payload' => $payload,
         ]);
     }
 
@@ -78,21 +79,21 @@ class LlmLoggingService
 
         // Database log
         LlmLog::create([
-            'session_id'   => $sessionId,
+            'session_id' => $sessionId,
             ...$meta,
             'message_type' => 'tool_call',
-            'content'      => [
-                'tool'      => $toolName,
+            'content' => [
+                'tool' => $toolName,
                 'arguments' => $arguments,
-                'result'    => $result,
+                'result' => $result,
             ],
-            'status'       => 'success',
+            'status' => 'success',
         ]);
 
         // File log
         $this->llmLog()->info("TOOL_CALL [{$sessionId}] {$toolName}", [
             'arguments' => $arguments,
-            'result'    => $result,
+            'result' => $result,
         ]);
     }
 
@@ -105,19 +106,19 @@ class LlmLoggingService
 
         // Database log
         LlmLog::create([
-            'session_id'    => $sessionId,
+            'session_id' => $sessionId,
             ...$meta,
-            'message_type'  => 'error',
-            'content'       => ['type' => class_basename($exception)],
-            'status'        => $errorStatus,
+            'message_type' => 'error',
+            'content' => ['type' => class_basename($exception)],
+            'status' => $errorStatus,
             'error_message' => $exception->getMessage(),
         ]);
 
         // File log
         $this->llmLog()->error("ERROR [{$sessionId}] {$errorStatus}", [
             'exception' => class_basename($exception),
-            'message'   => $exception->getMessage(),
-            'trace'     => $exception->getTraceAsString(),
+            'message' => $exception->getMessage(),
+            'trace' => $exception->getTraceAsString(),
         ]);
     }
 
@@ -136,20 +137,22 @@ class LlmLoggingService
                 } elseif (method_exists($msg, 'text')) {
                     $content = $msg->text();
                 }
+
                 return [
-                    'role'    => class_basename($msg),
+                    'role' => class_basename($msg),
                     'content' => $content,
                 ];
             }
+
             return $msg;
         }, $messages);
 
         // File log only (detailed)
         $this->llmLog()->debug("MESSAGES [{$sessionId}]", [
-            'provider'      => $meta['provider'],
-            'model'         => $meta['model'],
-            'system_prompt' => mb_substr($systemPrompt, 0, 500) . (mb_strlen($systemPrompt) > 500 ? '...' : ''),
-            'messages'      => $formatted,
+            'provider' => $meta['provider'],
+            'model' => $meta['model'],
+            'system_prompt' => mb_substr($systemPrompt, 0, 500).(mb_strlen($systemPrompt) > 500 ? '...' : ''),
+            'messages' => $formatted,
         ]);
     }
 
@@ -159,7 +162,7 @@ class LlmLoggingService
     public function logAssistantResponse(string $sessionId, string $text, array $toolCalls = []): void
     {
         $this->llmLog()->info("ASSISTANT [{$sessionId}]", [
-            'text'       => $text,
+            'text' => $text,
             'tool_calls' => $toolCalls,
         ]);
     }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Http\Middleware\HandleInertiaRequests;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
-use App\Http\Middleware\HandleInertiaRequests;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Providers\AppServiceProvider;
+
 return [
-    App\Providers\AppServiceProvider::class,
+    AppServiceProvider::class,
 ];

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\User;
+
 return [
 
     /*
@@ -62,7 +64,7 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => env('AUTH_MODEL', App\Models\User::class),
+            'model' => env('AUTH_MODEL', User::class),
         ],
 
         // 'users' => [

--- a/config/database.php
+++ b/config/database.php
@@ -2,6 +2,12 @@
 
 use Illuminate\Support\Str;
 
+$mysqlSslCaAttribute = extension_loaded('pdo_mysql')
+    ? (defined('Pdo\\Mysql::ATTR_SSL_CA')
+        ? constant('Pdo\\Mysql::ATTR_SSL_CA')
+        : constant('PDO::MYSQL_ATTR_SSL_CA'))
+    : null;
+
 return [
 
     /*
@@ -58,8 +64,8 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            'options' => $mysqlSslCaAttribute !== null ? array_filter([
+                $mysqlSslCaAttribute => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -78,8 +84,8 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            'options' => $mysqlSslCaAttribute !== null ? array_filter([
+                $mysqlSslCaAttribute => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 

--- a/database/factories/AccountFactory.php
+++ b/database/factories/AccountFactory.php
@@ -2,10 +2,11 @@
 
 namespace Database\Factories;
 
+use App\Models\Account;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Account>
+ * @extends Factory<Account>
  */
 class AccountFactory extends Factory
 {
@@ -18,12 +19,12 @@ class AccountFactory extends Factory
     {
         $accountTypes = ['savings', 'current', 'credit_card', 'cash', 'investment'];
         $banks = ['SBI', 'HDFC', 'ICICI', 'Axis', 'Kotak', 'PNB', 'BOB'];
-        
+
         $openingBalance = $this->faker->randomFloat(2, 1000, 100000);
-        
+
         return [
             'code' => strtoupper($this->faker->unique()->lexify('????')),
-            'name' => $this->faker->company . ' Account',
+            'name' => $this->faker->company.' Account',
             'type' => $this->faker->randomElement($accountTypes),
             'bank_name' => $this->faker->randomElement($banks),
             'account_number' => $this->faker->numerify('############'),

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -6,7 +6,7 @@ use App\Models\Category;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Category>
+ * @extends Factory<Category>
  */
 class CategoryFactory extends Factory
 {
@@ -21,23 +21,23 @@ class CategoryFactory extends Factory
             'Food & Dining', 'Transportation', 'Shopping', 'Entertainment',
             'Bills & Utilities', 'Healthcare', 'Education', 'Travel',
             'Salary', 'Business Income', 'Investment Returns', 'Freelancing',
-            'Gifts', 'Personal Care', 'Home & Garden', 'Auto & Transport'
+            'Gifts', 'Personal Care', 'Home & Garden', 'Auto & Transport',
         ];
-        
+
         $icons = [
             'utensils', 'car', 'shopping-cart', 'film',
             'receipt', 'heart', 'graduation-cap', 'plane',
             'wallet', 'briefcase', 'chart-line', 'laptop',
-            'gift', 'user', 'home', 'car-side'
+            'gift', 'user', 'home', 'car-side',
         ];
-        
+
         $colors = [
             '#3B82F6', '#EF4444', '#10B981', '#F59E0B',
             '#8B5CF6', '#06B6D4', '#84CC16', '#F97316',
             '#EC4899', '#6366F1', '#14B8A6', '#F43F5E',
-            '#8B5A2B', '#059669', '#7C3AED', '#DC2626'
+            '#8B5A2B', '#059669', '#7C3AED', '#DC2626',
         ];
-        
+
         return [
             'name' => $this->faker->randomElement($categoryNames),
             'code' => strtoupper($this->faker->unique()->lexify('???')),

--- a/database/migrations/2025_09_09_000000_drop_users_table.php
+++ b/database/migrations/2025_09_09_000000_drop_users_table.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     /**
      * Run the migrations.
      */

--- a/database/migrations/2025_09_09_000001_create_categories_table.php
+++ b/database/migrations/2025_09_09_000001_create_categories_table.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     /**
      * Run the migrations.
      */

--- a/database/migrations/2025_09_09_000002_create_accounts_table.php
+++ b/database/migrations/2025_09_09_000002_create_accounts_table.php
@@ -1,9 +1,11 @@
 <?php
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     public function up(): void
     {
         Schema::create('accounts', function (Blueprint $table) {

--- a/database/migrations/2025_09_09_000003_create_transactions_table.php
+++ b/database/migrations/2025_09_09_000003_create_transactions_table.php
@@ -1,9 +1,11 @@
 <?php
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     public function up(): void
     {
         Schema::create('transactions', function (Blueprint $table) {

--- a/database/migrations/2025_09_09_000004_create_preferences_table.php
+++ b/database/migrations/2025_09_09_000004_create_preferences_table.php
@@ -1,9 +1,11 @@
 <?php
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     public function up(): void
     {
         Schema::create('preferences', function (Blueprint $table) {

--- a/database/migrations/2025_09_16_230740_update_categories_icons.php
+++ b/database/migrations/2025_09_16_230740_update_categories_icons.php
@@ -1,8 +1,6 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
 
 return new class extends Migration
@@ -208,7 +206,7 @@ return new class extends Migration
             34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 96, 45, 46, 47, 48, 49, 50, 51, 52, 97,
             53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 98, 99, 100, 64, 65, 66, 67, 101,
             68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 102,
-            103, 104, 105, 106, 107, 108, 109, 110
+            103, 104, 105, 106, 107, 108, 109, 110,
         ];
 
         // Reset main categories

--- a/database/migrations/2026_01_19_154829_create_budgets_table.php
+++ b/database/migrations/2026_01_19_154829_create_budgets_table.php
@@ -25,9 +25,9 @@ return new class extends Migration
 
             // Foreign key constraint
             $table->foreign('category_id')
-                  ->references('id')
-                  ->on('categories')
-                  ->onDelete('cascade');
+                ->references('id')
+                ->on('categories')
+                ->onDelete('cascade');
         });
     }
 

--- a/database/migrations/2026_05_16_100000_add_transaction_time_to_transactions_table.php
+++ b/database/migrations/2026_05_16_100000_add_transaction_time_to_transactions_table.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     public function up(): void
     {
         Schema::table('transactions', function (Blueprint $table) {

--- a/database/seeders/AccountSeeder.php
+++ b/database/seeders/AccountSeeder.php
@@ -3,7 +3,6 @@
 namespace Database\Seeders;
 
 use App\Models\Account;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class AccountSeeder extends Seeder

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -14,7 +13,6 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
 
-        
         $this->call([
             CategorySeeder::class,
         ]);

--- a/tests/Feature/StatementReconcileTest.php
+++ b/tests/Feature/StatementReconcileTest.php
@@ -529,8 +529,7 @@ class StatementReconcileTest extends TestCase
 
         Log::shouldHaveReceived('info')
             ->once()
-            ->withArgs(fn (string $message, array $context): bool =>
-                $message === 'Statement reconciliation row needs detail'
+            ->withArgs(fn (string $message, array $context): bool => $message === 'Statement reconciliation row needs detail'
                 && $context['row_index'] === 0
                 && $context['statement_sequence'] === 2
                 && $context['account_id'] === $account->id

--- a/tests/Unit/DatabaseConfigCompatibilityTest.php
+++ b/tests/Unit/DatabaseConfigCompatibilityTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit;
+
+use ErrorException;
+use Tests\TestCase;
+
+class DatabaseConfigCompatibilityTest extends TestCase
+{
+    public function test_database_config_loads_without_php_deprecations(): void
+    {
+        set_error_handler(
+            static function (int $severity, string $message): never {
+                throw new ErrorException($message, 0, $severity);
+            },
+            E_DEPRECATED,
+        );
+
+        try {
+            $config = require dirname(__DIR__, 2).'/config/database.php';
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame('mysql', $config['connections']['mysql']['driver']);
+        $this->assertSame('mariadb', $config['connections']['mariadb']['driver']);
+    }
+}


### PR DESCRIPTION
## Summary
- apply Laravel Pint formatting across the existing PHP codebase without functional refactors
- select the supported namespaced MySQL SSL PDO constant on PHP 8.5 with a legacy fallback for older supported runtimes
- add a regression test that fails if database config loading emits PHP deprecations
- add `pint --test` to Laravel CI

## Verification
- `./vendor/bin/pint --test` — 105 files pass
- `composer test` — 83 tests, 446 assertions, zero deprecations
- `npm run build` — passes
- GitHub Actions passed while the PR temporarily targeted `main`
- MySQL and MariaDB SSL option configuration retains the supplied CA path
- independent review of all 34 changed files passed with no security or logic errors

## Stacked PR / conflict strategy
This PR intentionally targets `fix/issue-58-category-deletion-balance` because Pint formats `CategoryController.php`, which PR #70 changes. Merge #70 first. After #70 merges, retarget this PR to `main`; GitHub will then show only Issue #68 changes and avoid an overlapping-file conflict.

Depends on #70.
Closes #68